### PR TITLE
docs(readme): Expand README with full project overview

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -11,7 +11,7 @@
 
 1. Use latest versions of libraries and idiomatic approaches as of today
 2. Keep it simple - NEVER over-engineer, ALWAYS simplify, NO unnecessary defensive programming. No extra features - focus on simplicity.
-3. Be concise. Keep README minimal. IMPORTANT: no emojis ever
+3. Be concise. Keep README minimal by default. IMPORTANT: no emojis ever, except in README.md and PHILOSOPHY.md, where longer-form product narrative and emoji section headings are intentionally allowed.
 
 ## Git and GitHub
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -11,7 +11,7 @@
 
 1. Use latest versions of libraries and idiomatic approaches as of today
 2. Keep it simple - NEVER over-engineer, ALWAYS simplify, NO unnecessary defensive programming. No extra features - focus on simplicity.
-3. Be concise. Keep README minimal. IMPORTANT: no emojis ever
+3. Be concise. Keep README minimal by default. IMPORTANT: no emojis ever, except in README.md and PHILOSOPHY.md, where longer-form product narrative and emoji section headings are intentionally allowed.
 
 ## Git and GitHub
 

--- a/.windsurfrules
+++ b/.windsurfrules
@@ -11,7 +11,7 @@
 
 1. Use latest versions of libraries and idiomatic approaches as of today
 2. Keep it simple - NEVER over-engineer, ALWAYS simplify, NO unnecessary defensive programming. No extra features - focus on simplicity.
-3. Be concise. Keep README minimal. IMPORTANT: no emojis ever
+3. Be concise. Keep README minimal by default. IMPORTANT: no emojis ever, except in README.md and PHILOSOPHY.md, where longer-form product narrative and emoji section headings are intentionally allowed.
 
 ## Git and GitHub
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@
 
 1. Use latest versions of libraries and idiomatic approaches as of today
 2. Keep it simple - NEVER over-engineer, ALWAYS simplify, NO unnecessary defensive programming. No extra features - focus on simplicity.
-3. Be concise. Keep README minimal. IMPORTANT: no emojis ever
+3. Be concise. Keep README minimal by default. IMPORTANT: no emojis ever, except in README.md and PHILOSOPHY.md, where longer-form product narrative and emoji section headings are intentionally allowed.
 
 ## Git and GitHub
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@
 
 1. Use latest versions of libraries and idiomatic approaches as of today
 2. Keep it simple - NEVER over-engineer, ALWAYS simplify, NO unnecessary defensive programming. No extra features - focus on simplicity.
-3. Be concise. Keep README minimal. IMPORTANT: no emojis ever
+3. Be concise. Keep README minimal by default. IMPORTANT: no emojis ever, except in README.md and PHILOSOPHY.md, where longer-form product narrative and emoji section headings are intentionally allowed.
 
 ## Git and GitHub
 

--- a/PHILOSOPHY.md
+++ b/PHILOSOPHY.md
@@ -1,8 +1,4 @@
-# NoemaForge
-
-## Debug Your Mind: Journaling Web App
-
-Think of this app as a **rock-climbing gym for your brain**: each entry is a route from confusion to clarity, and the goal is to send problems cleanly. Journaling isn’t about precious diaries; it’s the mental equivalent of deploying code—**visible, testable and debuggable**. Below is the philosophy and the blueprint.
+# NoemaForge: Philosophy and Reasoning
 
 ## Why journaling matters
 
@@ -13,7 +9,7 @@ Journaling is self-debugging. When thoughts are written down, they become object
 - **Process emotions**: turning feelings into narratives reduces rumination; reflection good, rumination bad.  
 - **Surface next actions**: writing slows impulsive loops and exposes the real issue beneath the first reaction.  
 - **Keep receipts**: compare what you believed last month with now—course-correct and remember where you came from.  
-- **Think better**: good journaling is private cognitive engineering, not “dear diary”.
+- **Think better**: good journaling is private cognitive engineering, not "dear diary".
 
 ## Multi-modality capture
 
@@ -21,15 +17,15 @@ This app respects the way a fast brain works. It uses **three input modes**, eac
 
 ### 🗣️ Voice capture for raw dumps
 
-Sometimes your mind races faster than your fingers. Voice dictation lets you unload ideas, emotions or brainstorms while walking, driving or pacing. It’s like a first warm-up set: low friction and immediate. Dictation is a great capture tool; follow-up reflection happens in text for clarity.
+Sometimes your mind races faster than your fingers. Voice dictation lets you unload ideas, emotions or brainstorms while walking, driving or pacing. It's like a first warm-up set: low friction and immediate. Dictation is a great capture tool; follow-up reflection happens in text for clarity.
 
 ### ✍️ Handwriting OCR for deep reflection
 
-There’s an embodied magic in pen and paper. Studies suggest handwriting recruits broader brain networks and can deepen recall and reflection ([pmc.nih.gov](https://pmc.ncbi.nlm.nih.gov/articles/PMC11943480/)). If you prefer analog note-taking, snap a photo and let the app’s OCR pull your handwriting into your digital journal. This is for when you need to slow down and feel thoughts in your bones.
+There's an embodied magic in pen and paper. Studies suggest handwriting recruits broader brain networks and can deepen recall and reflection ([pmc.nih.gov](https://pmc.ncbi.nlm.nih.gov/articles/PMC11943480/)). If you prefer analog note-taking, snap a photo and let the app's OCR pull your handwriting into your digital journal. This is for when you need to slow down and feel thoughts in your bones.
 
 ### ⌨️ Typing as the backbone
 
-Typing is the workhorse. It’s fast, searchable, and keeps friction low enough that you’ll actually do it. Most of your notes live here; voice and handwriting are entry points into a common, text-based archive.
+Typing is the workhorse. It's fast, searchable, and keeps friction low enough that you'll actually do it. Most of your notes live here; voice and handwriting are entry points into a common, text-based archive.
 
 ## Flow: from capture to clarity
 
@@ -61,6 +57,6 @@ If you only do one thing, do this five-minute **mental reset**:
 
 ## Final thoughts
 
-This app isn’t just a place to store thoughts; it’s a **cognitive dojo**. Whether you capture ideas with your voice on a run, snap photos of your hand-written notes after climbing, or hammer out a long reflection on your keyboard, the goal is the same: turn mental chaos into decisions. It’s about clarity, continuity and making sure your mind’s output scales with the rest of your life.
+This app isn't just a place to store thoughts; it's a **cognitive dojo**. Whether you capture ideas with your voice on a run, snap photos of your hand-written notes after climbing, or hammer out a long reflection on your keyboard, the goal is the same: turn mental chaos into decisions. It's about clarity, continuity and making sure your mind's output scales with the rest of your life.
 
 Stay curious, stay honest and remember: the best journaling modality is the one you will actually use.

--- a/PHILOSOPHY.md
+++ b/PHILOSOPHY.md
@@ -1,5 +1,6 @@
 # NoemaForge: Philosophy and Reasoning
 
+> Note: This document is an explicit exception to the repo’s default assistant style guidance about keeping docs minimal and avoiding emojis. It is intended to be the canonical long-form philosophy for the project, so the emoji section headings and expanded narrative here are deliberate.
 ## Why journaling matters
 
 Journaling is self-debugging. When thoughts are written down, they become objects you can inspect rather than vague background fog. Research on expressive writing shows that structured reflection can improve metacognition, emotional processing, and decision-making ([apa.org](https://www.apa.org/news/podcasts/speaking-of-psychology/expressive-writing), [sciencedirect.com](https://www.sciencedirect.com/science/article/pii/S2666557322000131)).

--- a/PHILOSOPHY.md
+++ b/PHILOSOPHY.md
@@ -18,7 +18,7 @@ This app respects the way a fast brain works. It uses **three input modes**, eac
 
 ### 🗣️ Voice capture for raw dumps
 
-Sometimes your mind races faster than your fingers. Voice dictation lets you unload ideas, emotions or brainstorms while walking, driving or pacing. It’s like a first warm-up set: low friction and immediate. Dictation is a great capture tool; follow-up reflection happens in text for clarity.
+Sometimes your mind races faster than your fingers. Voice dictation lets you unload ideas, emotions or brainstorms while walking, pacing, or commuting when you’re not operating a vehicle. It’s like a first warm-up set: low friction and immediate. Dictation is a great capture tool; follow-up reflection happens in text for clarity.
 
 ### ✍️ Handwriting OCR for deep reflection
 

--- a/PHILOSOPHY.md
+++ b/PHILOSOPHY.md
@@ -9,7 +9,7 @@ Journaling is self-debugging. When thoughts are written down, they become object
 - **Process emotions**: turning feelings into narratives reduces rumination; reflection good, rumination bad.  
 - **Surface next actions**: writing slows impulsive loops and exposes the real issue beneath the first reaction.  
 - **Keep receipts**: compare what you believed last month with now—course-correct and remember where you came from.  
-- **Think better**: good journaling is private cognitive engineering, not "dear diary".
+- **Think better**: good journaling is private cognitive engineering, not “dear diary”.
 
 ## Multi-modality capture
 
@@ -17,15 +17,15 @@ This app respects the way a fast brain works. It uses **three input modes**, eac
 
 ### 🗣️ Voice capture for raw dumps
 
-Sometimes your mind races faster than your fingers. Voice dictation lets you unload ideas, emotions or brainstorms while walking, driving or pacing. It's like a first warm-up set: low friction and immediate. Dictation is a great capture tool; follow-up reflection happens in text for clarity.
+Sometimes your mind races faster than your fingers. Voice dictation lets you unload ideas, emotions or brainstorms while walking, driving or pacing. It’s like a first warm-up set: low friction and immediate. Dictation is a great capture tool; follow-up reflection happens in text for clarity.
 
 ### ✍️ Handwriting OCR for deep reflection
 
-There's an embodied magic in pen and paper. Studies suggest handwriting recruits broader brain networks and can deepen recall and reflection ([pmc.nih.gov](https://pmc.ncbi.nlm.nih.gov/articles/PMC11943480/)). If you prefer analog note-taking, snap a photo and let the app's OCR pull your handwriting into your digital journal. This is for when you need to slow down and feel thoughts in your bones.
+There’s an embodied magic in pen and paper. Studies suggest handwriting recruits broader brain networks and can deepen recall and reflection ([pmc.nih.gov](https://pmc.ncbi.nlm.nih.gov/articles/PMC11943480/)). If you prefer analog note-taking, snap a photo and let the app’s OCR pull your handwriting into your digital journal. This is for when you need to slow down and feel thoughts in your bones.
 
 ### ⌨️ Typing as the backbone
 
-Typing is the workhorse. It's fast, searchable, and keeps friction low enough that you'll actually do it. Most of your notes live here; voice and handwriting are entry points into a common, text-based archive.
+Typing is the workhorse. It’s fast, searchable, and keeps friction low enough that you’ll actually do it. Most of your notes live here; voice and handwriting are entry points into a common, text-based archive.
 
 ## Flow: from capture to clarity
 
@@ -57,6 +57,6 @@ If you only do one thing, do this five-minute **mental reset**:
 
 ## Final thoughts
 
-This app isn't just a place to store thoughts; it's a **cognitive dojo**. Whether you capture ideas with your voice on a run, snap photos of your hand-written notes after climbing, or hammer out a long reflection on your keyboard, the goal is the same: turn mental chaos into decisions. It's about clarity, continuity and making sure your mind's output scales with the rest of your life.
+This app isn’t just a place to store thoughts; it’s a **cognitive dojo**. Whether you capture ideas with your voice on a run, snap photos of your hand-written notes after climbing, or hammer out a long reflection on your keyboard, the goal is the same: turn mental chaos into decisions. It’s about clarity, continuity and making sure your mind’s output scales with the rest of your life.
 
 Stay curious, stay honest and remember: the best journaling modality is the one you will actually use.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,66 @@
-# noema-forge
-NoemaForge - Debug Your Mind: Journaling Web App
+# NoemaForge
+
+## Debug Your Mind: Journaling Web App
+
+Think of this app as a **rock-climbing gym for your brain**: each entry is a route from confusion to clarity, and the goal is to send problems cleanly. Journaling isn’t about precious diaries; it’s the mental equivalent of deploying code—**visible, testable and debuggable**. Below is the philosophy and the blueprint.
+
+## Why journaling matters
+
+Journaling is self-debugging. When thoughts are written down, they become objects you can inspect rather than vague background fog. Research on expressive writing shows that structured reflection can improve metacognition, emotional processing, and decision-making ([apa.org](https://www.apa.org/news/podcasts/speaking-of-psychology/expressive-writing?utm_source=chatgpt.com), [sciencedirect.com](https://www.sciencedirect.com/science/article/pii/S2666557322000131?utm_source=chatgpt.com)).
+
+- **Make the invisible visible**: externalise thoughts to reduce cognitive load and see the patterns behind them.  
+- **Sharpen self-awareness**: recurrent fears, triggers and assumptions reveal themselves when you track them.  
+- **Process emotions**: turning feelings into narratives reduces rumination; reflection good, rumination bad.  
+- **Surface next actions**: writing slows impulsive loops and exposes the real issue beneath the first reaction.  
+- **Keep receipts**: compare what you believed last month with now—course-correct and remember where you came from.  
+- **Think better**: good journaling is private cognitive engineering, not “dear diary”.
+
+## Multi-modality capture
+
+This app respects the way a fast brain works. It uses **three input modes**, each chosen for its strengths:
+
+### 🗣️ Voice capture for raw dumps
+
+Sometimes your mind races faster than your fingers. Voice dictation lets you unload ideas, emotions or brainstorms while walking, driving or pacing. It’s like a first warm-up set: low friction and immediate. Dictation is a great capture tool; follow-up reflection happens in text for clarity.
+
+### ✍️ Handwriting OCR for deep reflection
+
+There’s an embodied magic in pen and paper. Studies suggest handwriting recruits broader brain networks and can deepen recall and reflection ([pmc.nih.gov](https://pmc.ncbi.nlm.nih.gov/articles/PMC11943480/?utm_source=chatgpt.com)). If you prefer analog note-taking, snap a photo and let the app’s OCR pull your handwriting into your digital journal. This is for when you need to slow down and feel thoughts in your bones.
+
+### ⌨️ Typing as the backbone
+
+Typing is the workhorse. It’s fast, searchable, and keeps friction low enough that you’ll actually do it. Most of your notes live here; voice and handwriting are entry points into a common, text-based archive.
+
+## Flow: from capture to clarity
+
+Every mode funnels into the same **reflective pipeline**, designed for a distractible, high-powered brain:
+
+1. **Dump** — speak, write, or scribble without censoring yourself.  
+2. **Sort** — the app automatically tags facts, feelings and tasks.  
+3. **Distill** — answer three questions: *What am I actually feeling?* *What is the real issue?* *What is the next move?*  
+4. **Store** — your distilled insights are saved in plain text, ready for search and synthesis later.
+
+Follow-up questions always invite you to switch to touch-typing to refine your thoughts. That switch matters: capturing and clarifying are distinct moves, like transitioning from mount to back control in Brazilian Jiu-Jitsu. One mode gathers raw material; the other crafts it into something useful.
+
+## Feature highlights
+
+- **Cross-modal capture** – voice, handwriting and typing all feed one journal.  
+- **Automatic follow-up prompts** – after every capture, the app asks questions to turn rambling into reflection.  
+- **Low friction** – keep your brain out of RAM and onto the page quickly.  
+- **Searchable history** – find patterns over months or years; compare your current beta to your old attempts.  
+- **Evidence-oriented** – built on research into expressive writing, metacognition and journaling benefits
+
+## Minimal viable routine
+
+If you only do one thing, do this five-minute **mental reset**:
+
+1. Dump everything for two minutes (voice or typed).  
+2. Underline what is fact, fear, desire or task.  
+3. Answer: *The real issue is…* *What matters most is…* *Next step is…*  
+4. Store it. Future-you will thank past-you.
+
+## Final thoughts
+
+This app isn’t just a place to store thoughts; it’s a **cognitive dojo**. Whether you capture ideas with your voice on a run, snap photos of your hand-written notes after climbing, or hammer out a long reflection on your keyboard, the goal is the same: turn mental chaos into decisions. It’s about clarity, continuity and making sure your mind’s output scales with the rest of your life.
+
+Stay curious, stay honest and remember: the best journaling modality is the one you will actually use.

--- a/README.md
+++ b/README.md
@@ -2,65 +2,16 @@
 
 ## Debug Your Mind: Journaling Web App
 
-Think of this app as a **rock-climbing gym for your brain**: each entry is a route from confusion to clarity, and the goal is to send problems cleanly. Journaling isn’t about precious diaries; it’s the mental equivalent of deploying code—**visible, testable and debuggable**. Below is the philosophy and the blueprint.
+NoemaForge is a journaling web app focused on turning raw thoughts into clearer, searchable reflections.
 
-## Why journaling matters
+## Overview
 
-Journaling is self-debugging. When thoughts are written down, they become objects you can inspect rather than vague background fog. Research on expressive writing shows that structured reflection can improve metacognition, emotional processing, and decision-making ([apa.org](https://www.apa.org/news/podcasts/speaking-of-psychology/expressive-writing), [sciencedirect.com](https://www.sciencedirect.com/science/article/pii/S2666557322000131)).
+The project is intended to support low-friction journal capture across multiple input modes, including typing, voice, and handwriting OCR.
 
-- **Make the invisible visible**: externalise thoughts to reduce cognitive load and see the patterns behind them.  
-- **Sharpen self-awareness**: recurrent fears, triggers and assumptions reveal themselves when you track them.  
-- **Process emotions**: turning feelings into narratives reduces rumination; reflection good, rumination bad.  
-- **Surface next actions**: writing slows impulsive loops and exposes the real issue beneath the first reaction.  
-- **Keep receipts**: compare what you believed last month with now—course-correct and remember where you came from.  
-- **Think better**: good journaling is private cognitive engineering, not “dear diary”.
+Planned capabilities:
 
-## Multi-modality capture
+- Cross-modal capture in a single journal
+- Follow-up prompts to refine raw input into reflection
+- Searchable history for pattern tracking over time
 
-This app respects the way a fast brain works. It uses **three input modes**, each chosen for its strengths:
-
-### 🗣️ Voice capture for raw dumps
-
-Sometimes your mind races faster than your fingers. Voice dictation lets you unload ideas, emotions or brainstorms while walking, driving or pacing. It’s like a first warm-up set: low friction and immediate. Dictation is a great capture tool; follow-up reflection happens in text for clarity.
-
-### ✍️ Handwriting OCR for deep reflection
-
-There’s an embodied magic in pen and paper. Studies suggest handwriting recruits broader brain networks and can deepen recall and reflection ([pmc.nih.gov](https://pmc.ncbi.nlm.nih.gov/articles/PMC11943480/)). If you prefer analog note-taking, snap a photo and let the app’s OCR pull your handwriting into your digital journal. This is for when you need to slow down and feel thoughts in your bones.
-
-### ⌨️ Typing as the backbone
-
-Typing is the workhorse. It’s fast, searchable, and keeps friction low enough that you’ll actually do it. Most of your notes live here; voice and handwriting are entry points into a common, text-based archive.
-
-## Flow: from capture to clarity
-
-The intended experience is a **reflective pipeline** for a distractible, high-powered brain:
-
-1. **Dump** — speak, write, or scribble without censoring yourself.  
-2. **Sort** — the app is intended to help tag facts, feelings and tasks.  
-3. **Distill** — answer three questions: *What am I actually feeling?* *What is the real issue?* *What is the next move?*  
-4. **Store** — the goal is to save distilled insights in plain text, ready for search and synthesis later.
-
-Follow-up questions are intended to invite you to switch to touch-typing to refine your thoughts. That switch matters: capturing and clarifying are distinct moves, like transitioning from mount to back control in Brazilian Jiu-Jitsu. One mode gathers raw material; the other crafts it into something useful.
-
-## Product vision and planned capabilities
-
-- **Planned: cross-modal capture** – voice, handwriting and typing would feed one journal.  
-- **Planned: automatic follow-up prompts** – after capture, the app would ask questions to turn rambling into reflection.  
-- **Goal: low friction** – help get thoughts out of RAM and onto the page quickly.  
-- **Planned: searchable history** – make it easier to find patterns over months or years and compare current thinking with older entries.  
-- **Evidence-oriented approach** – the product direction is informed by research into expressive writing, metacognition and journaling benefits.
-
-## Minimal viable routine
-
-If you only do one thing, do this five-minute **mental reset**:
-
-1. Dump everything for two minutes (voice or typed).  
-2. Underline what is fact, fear, desire or task.  
-3. Answer: *The real issue is…* *What matters most is…* *Next step is…*  
-4. Store it. Future-you will thank past-you.
-
-## Final thoughts
-
-This app isn’t just a place to store thoughts; it’s a **cognitive dojo**. Whether you capture ideas with your voice on a run, snap photos of your hand-written notes after climbing, or hammer out a long reflection on your keyboard, the goal is the same: turn mental chaos into decisions. It’s about clarity, continuity and making sure your mind’s output scales with the rest of your life.
-
-Stay curious, stay honest and remember: the best journaling modality is the one you will actually use.
+See [PHILOSOPHY.md](PHILOSOPHY.md) for the detailed product philosophy, rationale, and longer-form background.


### PR DESCRIPTION
Closes #3

Replaces the 2-line stub with a full project overview including:
- Project philosophy and journaling rationale
- Multi-modality capture (voice, handwriting OCR, typing)
- Reflective pipeline flow
- Feature highlights
- Minimal viable routine