### PR TITLE
docs(readme): Document future LLM roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,6 @@ Planned capabilities:
 - Follow-up prompts to refine raw input into reflection
 - Searchable history for pattern tracking over time
 - Future LLM support would likely use open-source models served by a separately hosted Ollama instance (for example, on a self-hosted VM), with the Vercel-hosted app calling that service
-- LLM use would stay narrow: generate a specific "Next action?" question and offer 2-3 next-step suggestions based on the identified root cause problem
+- LLM use would stay narrow: generate a specific "Next step" question and offer 2-3 next-step suggestions based on the identified root cause problem
 
 See [PHILOSOPHY.md](PHILOSOPHY.md) for the detailed product philosophy, rationale, and longer-form background.

--- a/README.md
+++ b/README.md
@@ -15,5 +15,7 @@ Planned capabilities:
 - Cross-modal capture in a single journal
 - Follow-up prompts to refine raw input into reflection
 - Searchable history for pattern tracking over time
+- Future LLM support would likely use Ollama-backed open-source models on the server side of the Vercel-hosted app
+- LLM use would stay narrow: generate a specific "Next action?" question and offer 2-3 next-step suggestions based on the identified root cause problem
 
 See [PHILOSOPHY.md](PHILOSOPHY.md) for the detailed product philosophy, rationale, and longer-form background.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Planned capabilities:
 - Cross-modal capture in a single journal
 - Follow-up prompts to refine raw input into reflection
 - Searchable history for pattern tracking over time
-- Future LLM support would likely use Ollama-backed open-source models on the server side of the Vercel-hosted app
+- Future LLM support would likely use open-source models served by a separately hosted Ollama instance (for example, on a self-hosted VM), with the Vercel-hosted app calling that service
 - LLM use would stay narrow: generate a specific "Next action?" question and offer 2-3 next-step suggestions based on the identified root cause problem
 
 See [PHILOSOPHY.md](PHILOSOPHY.md) for the detailed product philosophy, rationale, and longer-form background.


### PR DESCRIPTION
## Summary
- add README notes for planned Ollama-backed open-source model support on the server side of the Vercel-hosted app
- document that LLM use is intended mainly for a focused "Next action?" prompt and 2-3 next-step suggestions based on the identified root cause problem

## Testing
- verified the README markdown and git diff locally

Closes #6