### PR TITLE
fix(bootstrap): Address PR #11 review feedback

### DIFF
--- a/src/app/api/health/route.test.ts
+++ b/src/app/api/health/route.test.ts
@@ -1,24 +1,19 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { GET } from "@/app/api/health/route";
 
-const originalEnv = { ...process.env };
-
 afterEach(() => {
-  process.env = { ...originalEnv };
+  vi.unstubAllEnvs();
 });
 
 describe("GET /api/health", () => {
   it("returns a healthy payload without requiring runtime integrations", async () => {
-    process.env = {
-      ...originalEnv,
-      NEXT_PUBLIC_APP_NAME: "NoemaForge Test",
-    };
-    delete process.env.DATABASE_URL;
-    delete process.env.DATABASE_URL_NON_POOLING;
-    delete process.env.S3_ACCESS_KEY_ID;
-    delete process.env.S3_BUCKET;
-    delete process.env.S3_ENDPOINT;
-    delete process.env.S3_SECRET_ACCESS_KEY;
+    vi.stubEnv("NEXT_PUBLIC_APP_NAME", "NoemaForge Test");
+    vi.stubEnv("DATABASE_URL", undefined);
+    vi.stubEnv("DATABASE_URL_NON_POOLING", undefined);
+    vi.stubEnv("S3_ACCESS_KEY_ID", undefined);
+    vi.stubEnv("S3_BUCKET", undefined);
+    vi.stubEnv("S3_ENDPOINT", undefined);
+    vi.stubEnv("S3_SECRET_ACCESS_KEY", undefined);
 
     const response = await GET();
     const body = (await response.json()) as {

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -13,6 +13,7 @@ const createdAt = timestamp("created_at", { withTimezone: true })
 
 const updatedAt = timestamp("updated_at", { withTimezone: true })
   .defaultNow()
+  .$onUpdate(() => new Date())
   .notNull();
 
 export const captureSource = pgEnum("capture_source", ["typed", "voice", "ocr"]);

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,8 +1,11 @@
+import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   resolve: {
-    tsconfigPaths: true,
+    alias: {
+      "@": fileURLToPath(new URL("./src", import.meta.url)),
+    },
   },
   test: {
     environment: "node",


### PR DESCRIPTION
## Why
PR #11 has three unresolved review comments that should be fixed before merge.

## What changed
- replace the non-standard Vitest path-resolution setting with an explicit `@` alias
- stop reassigning `process.env` in the health route test and use `vi.stubEnv` instead
- make `updated_at` advance on updates via Drizzle's ORM hook

## Success criteria
- the three review comments on PR #11 are directly addressed
- lint, unit tests, build, and Playwright smoke tests pass
- the patch is ready to merge back into `chore/app-bootstrap`

## Out of scope
- broader bootstrap refactors
- new product features
