### PR TITLE
feat(auth): Add Auth.js credentials alternative #15

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,14 @@
 NEXT_PUBLIC_APP_NAME=NoemaForge
 NEXT_PUBLIC_APP_URL=http://127.0.0.1:3000
 
+# Keep "journal" for the default first-party session flow.
+# Set "authjs-credentials" to use the optional Auth.js credentials sign-in path.
+AUTH_SIGN_IN_MODE=journal
+# Required when AUTH_SIGN_IN_MODE=authjs-credentials.
+AUTH_SECRET=
+# Set to true when the app runs behind a proxy that forwards host/proto headers.
+AUTH_TRUST_HOST=false
+
 DATABASE_URL=postgres://postgres:postgres@127.0.0.1:5432/noema_forge
 DATABASE_URL_NON_POOLING=postgres://postgres:postgres@127.0.0.1:5432/noema_forge
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ The app runs at `http://127.0.0.1:3000`. Open it to create a journal account or 
 
 The sign-in page and health route still load without Postgres configured, but account creation, journal entry saves, edits, and search require `DATABASE_URL`.
 
+By default, auth stays on the first-party journal session flow. To enable the optional Auth.js credentials alternative, set `AUTH_SIGN_IN_MODE=authjs-credentials`, provide `AUTH_SECRET`, and set `AUTH_TRUST_HOST=true` if your deployment relies on forwarded proxy headers. The same journal user records and entry routes stay in place; only the sign-in/session mechanism changes.
+
 ## Scripts
 
 | Command | Purpose |

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@aws-sdk/client-s3": "3.1029.0",
         "drizzle-orm": "0.45.2",
         "next": "16.2.3",
+        "next-auth": "^5.0.0-beta.31",
         "postgres": "3.4.9",
         "react": "19.2.5",
         "react-dom": "19.2.5",
@@ -98,6 +99,35 @@
       "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@auth/core": {
+      "version": "0.41.2",
+      "resolved": "https://registry.npmjs.org/@auth/core/-/core-0.41.2.tgz",
+      "integrity": "sha512-Hx5MNBxN2fJTbJKGUKAA0wca43D0Akl3TvufY54Gn8lop7F+34vU1zA1pn0vQfIoVuLIrpfc2nkyjwIaPJMW7w==",
+      "license": "ISC",
+      "dependencies": {
+        "@panva/hkdf": "^1.2.1",
+        "jose": "^6.0.6",
+        "oauth4webapi": "^3.3.0",
+        "preact": "10.24.3",
+        "preact-render-to-string": "6.5.11"
+      },
+      "peerDependencies": {
+        "@simplewebauthn/browser": "^9.0.1",
+        "@simplewebauthn/server": "^9.0.2",
+        "nodemailer": "^7.0.7"
+      },
+      "peerDependenciesMeta": {
+        "@simplewebauthn/browser": {
+          "optional": true
+        },
+        "@simplewebauthn/server": {
+          "optional": true
+        },
+        "nodemailer": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@aws-crypto/crc32": {
       "version": "5.2.0",
@@ -2772,6 +2802,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@panva/hkdf": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@panva/hkdf/-/hkdf-1.2.1.tgz",
+      "integrity": "sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/@playwright/test": {
@@ -8089,6 +8128,15 @@
         "jiti": "lib/jiti-cli.mjs"
       }
     },
+    "node_modules/jose": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
+      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -8769,6 +8817,33 @@
         }
       }
     },
+    "node_modules/next-auth": {
+      "version": "5.0.0-beta.31",
+      "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-5.0.0-beta.31.tgz",
+      "integrity": "sha512-1OBgCKPzo+S7UWWMp3xgvGvIJ0OpV7B3vR4ZDRqD9a4Ch+OT6dakLXG9ivhtmIWVa71nTSXattOHyCg8sNi8/Q==",
+      "license": "ISC",
+      "dependencies": {
+        "@auth/core": "0.41.2"
+      },
+      "peerDependencies": {
+        "@simplewebauthn/browser": "^9.0.1",
+        "@simplewebauthn/server": "^9.0.2",
+        "next": "^14.0.0-0 || ^15.0.0 || ^16.0.0",
+        "nodemailer": "^7.0.7",
+        "react": "^18.2.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@simplewebauthn/browser": {
+          "optional": true
+        },
+        "@simplewebauthn/server": {
+          "optional": true
+        },
+        "nodemailer": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/next/node_modules/postcss": {
       "version": "8.4.31",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
@@ -8822,6 +8897,15 @@
       "integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/oauth4webapi": {
+      "version": "3.8.5",
+      "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.8.5.tgz",
+      "integrity": "sha512-A8jmyUckVhRJj5lspguklcl90Ydqk61H3dcU0oLhH3Yv13KpAliKTt5hknpGGPZSSfOwGyraNEFmofDYH+1kSg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -9201,6 +9285,25 @@
       "funding": {
         "type": "individual",
         "url": "https://github.com/sponsors/porsager"
+      }
+    },
+    "node_modules/preact": {
+      "version": "10.24.3",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.24.3.tgz",
+      "integrity": "sha512-Z2dPnBnMUfyQfSQ+GBdsGa16hz35YmLmtTLhM169uW944hYL6xzTYkJjC07j+Wosz733pMWx0fgON3JNw1jJQA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
+    "node_modules/preact-render-to-string": {
+      "version": "6.5.11",
+      "resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-6.5.11.tgz",
+      "integrity": "sha512-ubnauqoGczeGISiOh6RjX0/cdaF8v/oDXIjO85XALCQjwQP+SB4RDXXtvZ6yTYSjG+PC1QRP2AhPgCEsM2EvUw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "preact": ">=10"
       }
     },
     "node_modules/prelude-ls": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@aws-sdk/client-s3": "3.1029.0",
         "drizzle-orm": "0.45.2",
         "next": "16.2.3",
-        "next-auth": "^5.0.0-beta.31",
+        "next-auth": "5.0.0-beta.31",
         "postgres": "3.4.9",
         "react": "19.2.5",
         "react-dom": "19.2.5",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@aws-sdk/client-s3": "3.1029.0",
     "drizzle-orm": "0.45.2",
     "next": "16.2.3",
+    "next-auth": "^5.0.0-beta.31",
     "postgres": "3.4.9",
     "react": "19.2.5",
     "react-dom": "19.2.5",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@aws-sdk/client-s3": "3.1029.0",
     "drizzle-orm": "0.45.2",
     "next": "16.2.3",
-    "next-auth": "^5.0.0-beta.31",
+    "next-auth": "5.0.0-beta.31",
     "postgres": "3.4.9",
     "react": "19.2.5",
     "react-dom": "19.2.5",

--- a/src/app/api/auth/[...nextauth]/route.test.ts
+++ b/src/app/api/auth/[...nextauth]/route.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@/auth", () => ({
+  handlers: {
+    GET: vi.fn(() => Response.json({ ok: true })),
+    POST: vi.fn(() => Response.json({ ok: true })),
+  },
+}));
+
+vi.mock("@/lib/env", () => ({
+  usesAuthJsCredentials: vi.fn(),
+}));
+
+import { GET, POST } from "@/app/api/auth/[...nextauth]/route";
+import { handlers } from "@/auth";
+import { usesAuthJsCredentials } from "@/lib/env";
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("/api/auth/[...nextauth]", () => {
+  it("returns 404 when the optional Auth.js mode is disabled", async () => {
+    vi.mocked(usesAuthJsCredentials).mockReturnValue(false);
+
+    const response = await GET(
+      new NextRequest("http://127.0.0.1:3000/api/auth/session"),
+    );
+
+    expect(response.status).toBe(404);
+    expect(handlers.GET).not.toHaveBeenCalled();
+  });
+
+  it("delegates to Auth.js handlers when the optional mode is enabled", async () => {
+    vi.mocked(usesAuthJsCredentials).mockReturnValue(true);
+
+    await POST(new NextRequest("http://127.0.0.1:3000/api/auth/signin"));
+
+    expect(handlers.POST).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { handlers } from "@/auth";
+import { usesAuthJsCredentials } from "@/lib/env";
+
+function getDisabledResponse() {
+  return NextResponse.json({ error: "Not found." }, { status: 404 });
+}
+
+export async function GET(request: NextRequest) {
+  if (!usesAuthJsCredentials()) {
+    return getDisabledResponse();
+  }
+
+  return handlers.GET(request);
+}
+
+export async function POST(request: NextRequest) {
+  if (!usesAuthJsCredentials()) {
+    return getDisabledResponse();
+  }
+
+  return handlers.POST(request);
+}

--- a/src/app/entries/[entryId]/edit/page.tsx
+++ b/src/app/entries/[entryId]/edit/page.tsx
@@ -57,6 +57,7 @@ export default async function EditEntryPage({
         description="Update the typed text and keep the entry in the same searchable archive."
         error={error ? editErrorMessages[error] : undefined}
         heading="Revise this entry"
+        key={entry.id}
         submitLabel="Save changes"
       />
     </JournalChrome>

--- a/src/app/entries/[entryId]/edit/page.tsx
+++ b/src/app/entries/[entryId]/edit/page.tsx
@@ -1,8 +1,9 @@
 import { notFound } from "next/navigation";
 import { JournalChrome } from "@/components/journal-chrome";
+import { signOutWithAuthJsCredentials } from "@/lib/auth/authjs-actions";
 import { JournalEntryForm } from "@/components/journal-entry-form";
 import { requireCurrentUser } from "@/lib/auth/current-user";
-import { readServerEnv } from "@/lib/env";
+import { readServerEnv, usesAuthJsCredentials } from "@/lib/env";
 import { getJournalEntry } from "@/lib/journal/service";
 import { getSingleSearchParam } from "@/lib/search-params";
 
@@ -28,6 +29,9 @@ export default async function EditEntryPage({
   }
 
   const env = readServerEnv();
+  const signOutAction = usesAuthJsCredentials(env)
+    ? signOutWithAuthJsCredentials
+    : "/auth/sign-out";
   const error = getSingleSearchParam((await searchParams).error);
 
   return (
@@ -42,6 +46,7 @@ export default async function EditEntryPage({
       }
       appName={env.NEXT_PUBLIC_APP_NAME}
       description="Refine the text while keeping the original entry history private and searchable."
+      signOutAction={signOutAction}
       title="Edit entry"
       userEmail={user.email}
     >

--- a/src/app/entries/[entryId]/page.tsx
+++ b/src/app/entries/[entryId]/page.tsx
@@ -2,8 +2,9 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 import { EntryMetadata } from "@/components/entry-metadata";
 import { JournalChrome } from "@/components/journal-chrome";
+import { signOutWithAuthJsCredentials } from "@/lib/auth/authjs-actions";
 import { requireCurrentUser } from "@/lib/auth/current-user";
-import { readServerEnv } from "@/lib/env";
+import { readServerEnv, usesAuthJsCredentials } from "@/lib/env";
 import { getJournalEntry } from "@/lib/journal/service";
 import { getSingleSearchParam } from "@/lib/search-params";
 
@@ -30,6 +31,9 @@ export default async function EntryDetailPage({
   }
 
   const env = readServerEnv();
+  const signOutAction = usesAuthJsCredentials(env)
+    ? signOutWithAuthJsCredentials
+    : "/auth/sign-out";
   const message = getSingleSearchParam((await searchParams).message);
 
   return (
@@ -52,6 +56,7 @@ export default async function EntryDetailPage({
       }
       appName={env.NEXT_PUBLIC_APP_NAME}
       description="Review the full text and metadata for a typed journal entry."
+      signOutAction={signOutAction}
       title="Entry detail"
       userEmail={user.email}
     >

--- a/src/app/entries/[entryId]/update/route.test.ts
+++ b/src/app/entries/[entryId]/update/route.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { NextRequest } from "next/server";
 
+vi.mock("@/auth", () => ({
+  auth: vi.fn((handler) => handler),
+}));
+
 vi.mock("@/lib/auth/request", () => ({
   getRequestUser: vi.fn(),
 }));

--- a/src/app/entries/[entryId]/update/route.ts
+++ b/src/app/entries/[entryId]/update/route.ts
@@ -1,4 +1,6 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextResponse } from "next/server";
+import type { NextAuthRequest } from "next-auth";
+import { auth } from "@/auth";
 import { getRequestUser } from "@/lib/auth/request";
 import { JournalError, updateJournalEntry } from "@/lib/journal/service";
 import { getRequestUrl } from "@/lib/request-url";
@@ -7,8 +9,8 @@ type EntryUpdateRouteContext = {
   params: Promise<{ entryId: string }>;
 };
 
-export async function POST(
-  request: NextRequest,
+async function handlePost(
+  request: NextAuthRequest,
   context: EntryUpdateRouteContext,
 ) {
   const user = await getRequestUser(request);
@@ -46,3 +48,5 @@ export async function POST(
     throw error;
   }
 }
+
+export const POST = auth(handlePost);

--- a/src/app/entries/route.test.ts
+++ b/src/app/entries/route.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { NextRequest } from "next/server";
 
+vi.mock("@/auth", () => ({
+  auth: vi.fn((handler) => handler),
+}));
+
 vi.mock("@/lib/auth/request", () => ({
   getRequestUser: vi.fn(),
 }));

--- a/src/app/entries/route.ts
+++ b/src/app/entries/route.ts
@@ -1,9 +1,11 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextResponse } from "next/server";
+import type { NextAuthRequest } from "next-auth";
+import { auth } from "@/auth";
 import { getRequestUser } from "@/lib/auth/request";
 import { JournalError, createJournalEntry } from "@/lib/journal/service";
 import { getRequestUrl } from "@/lib/request-url";
 
-export async function POST(request: NextRequest) {
+async function handlePost(request: NextAuthRequest) {
   const user = await getRequestUser(request);
 
   if (!user) {
@@ -35,3 +37,5 @@ export async function POST(request: NextRequest) {
     throw error;
   }
 }
+
+export const POST = auth(handlePost);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -42,6 +42,7 @@ export default async function Home({ searchParams }: HomePageProps) {
       <div className="grid gap-6 xl:grid-cols-[minmax(0,0.92fr)_minmax(0,1.08fr)]">
         <JournalEntryForm
           action="/entries"
+          key="new-entry"
           description="Typing is the default capture path for this slice. Save raw thoughts here, then review or edit them from the archive."
           error={error ? homeErrorMessages[error] : undefined}
           heading="New typed entry"

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,8 +1,9 @@
 import { EntryMetadata } from "@/components/entry-metadata";
 import { JournalChrome } from "@/components/journal-chrome";
+import { signOutWithAuthJsCredentials } from "@/lib/auth/authjs-actions";
 import { JournalEntryForm } from "@/components/journal-entry-form";
 import { requireCurrentUser } from "@/lib/auth/current-user";
-import { readServerEnv } from "@/lib/env";
+import { readServerEnv, usesAuthJsCredentials } from "@/lib/env";
 import { excerptText } from "@/lib/formatting";
 import { listJournalEntries } from "@/lib/journal/service";
 import { getSingleSearchParam } from "@/lib/search-params";
@@ -23,6 +24,9 @@ export default async function Home({ searchParams }: HomePageProps) {
   const user = await requireCurrentUser();
   const params = await searchParams;
   const env = readServerEnv();
+  const signOutAction = usesAuthJsCredentials(env)
+    ? signOutWithAuthJsCredentials
+    : "/auth/sign-out";
   const query = getSingleSearchParam(params.q)?.trim() ?? "";
   const error = getSingleSearchParam(params.error);
   const entries = await listJournalEntries({ query }, user.id);
@@ -31,6 +35,7 @@ export default async function Home({ searchParams }: HomePageProps) {
     <JournalChrome
       appName={env.NEXT_PUBLIC_APP_NAME}
       description="Capture typed thoughts, edit them later, and search the archive without leaving your private journal."
+      signOutAction={signOutAction}
       title="Journal history"
       userEmail={user.email}
     >

--- a/src/app/sign-in/page.tsx
+++ b/src/app/sign-in/page.tsx
@@ -1,6 +1,10 @@
 import { AuthPage } from "@/components/auth-page";
+import {
+  registerWithAuthJsCredentials,
+  signInWithAuthJsCredentials,
+} from "@/lib/auth/authjs-actions";
 import { redirectIfAuthenticated } from "@/lib/auth/current-user";
-import { readServerEnv } from "@/lib/env";
+import { readServerEnv, usesAuthJsCredentials } from "@/lib/env";
 import { getSingleSearchParam } from "@/lib/search-params";
 
 type SignInPageProps = {
@@ -15,12 +19,22 @@ export default async function SignInPage({ searchParams }: SignInPageProps) {
 
   const params = await searchParams;
   const env = readServerEnv();
+  const authJsCredentialsEnabled = usesAuthJsCredentials(env);
 
   return (
     <AuthPage
       appName={env.NEXT_PUBLIC_APP_NAME}
       error={getSingleSearchParam(params.error)}
       message={getSingleSearchParam(params.message)}
+      registerAction={
+        authJsCredentialsEnabled
+          ? registerWithAuthJsCredentials
+          : "/auth/register"
+      }
+      signInAction={
+        authJsCredentialsEnabled ? signInWithAuthJsCredentials : "/auth/sign-in"
+      }
+      useAuthJsCredentials={authJsCredentialsEnabled}
     />
   );
 }

--- a/src/auth.test.ts
+++ b/src/auth.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { credentialsProvider, nextAuth } = vi.hoisted(() => ({
+  credentialsProvider: vi.fn((config) => config),
+  nextAuth: vi.fn(() => ({
+    auth: vi.fn(),
+    handlers: {
+      GET: vi.fn(),
+      POST: vi.fn(),
+    },
+    signIn: vi.fn(),
+    signOut: vi.fn(),
+  })),
+}));
+
+vi.mock("next-auth", () => ({
+  default: nextAuth,
+}));
+
+vi.mock("next-auth/providers/credentials", () => ({
+  default: credentialsProvider,
+}));
+
+vi.mock("@/lib/auth/service", () => ({
+  AuthError: class AuthError extends Error {},
+  authenticateUser: vi.fn(),
+}));
+
+afterEach(() => {
+  vi.resetModules();
+  vi.clearAllMocks();
+  vi.unstubAllEnvs();
+});
+
+describe("auth configuration", () => {
+  it("passes static config to NextAuth so route wrappers stay synchronous", async () => {
+    vi.stubEnv("NEXT_PUBLIC_APP_NAME", "NoemaForge");
+    vi.stubEnv("NEXT_PUBLIC_APP_URL", "http://127.0.0.1:3000");
+
+    await import("@/auth");
+
+    expect(nextAuth).toHaveBeenCalledTimes(1);
+    expect(typeof vi.mocked(nextAuth).mock.calls[0]?.[0]).toBe("object");
+  });
+
+  it("only adds the credentials provider when the optional mode is enabled", async () => {
+    vi.stubEnv("AUTH_SECRET", "test-secret");
+    vi.stubEnv("AUTH_SIGN_IN_MODE", "authjs-credentials");
+    vi.stubEnv("NEXT_PUBLIC_APP_NAME", "NoemaForge");
+    vi.stubEnv("NEXT_PUBLIC_APP_URL", "http://127.0.0.1:3000");
+
+    await import("@/auth");
+
+    expect(credentialsProvider).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/auth.test.ts
+++ b/src/auth.test.ts
@@ -53,4 +53,44 @@ describe("auth configuration", () => {
 
     expect(credentialsProvider).toHaveBeenCalledTimes(1);
   });
+
+  it("leaves session dates unset when JWT claims are missing", async () => {
+    vi.stubEnv("NEXT_PUBLIC_APP_NAME", "NoemaForge");
+    vi.stubEnv("NEXT_PUBLIC_APP_URL", "http://127.0.0.1:3000");
+
+    await import("@/auth");
+
+    const config = vi.mocked(nextAuth).mock.calls[0]?.[0] as {
+      callbacks: {
+        session: (args: {
+          session: {
+            expires: string;
+            user: {
+              email?: string | null;
+              image?: string | null;
+              name?: string | null;
+            };
+          };
+          token: Record<string, unknown>;
+        }) => Promise<{
+          expires: string;
+          user: {
+            createdAt?: Date;
+            updatedAt?: Date;
+          } & Record<string, unknown>;
+        }>;
+      };
+    };
+
+    const session = await config.callbacks.session({
+      session: {
+        expires: "2030-01-01T00:00:00.000Z",
+        user: {},
+      },
+      token: {},
+    });
+
+    expect(session.user.createdAt).toBeUndefined();
+    expect(session.user.updatedAt).toBeUndefined();
+  });
 });

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,4 +1,4 @@
-import { createHash } from "node:crypto";
+import { randomBytes } from "node:crypto";
 import NextAuth from "next-auth";
 import Credentials from "next-auth/providers/credentials";
 import type { NextAuthConfig } from "next-auth";
@@ -15,9 +15,7 @@ const env = readServerEnv();
 const authJsCredentialsEnabled = usesAuthJsCredentials(env);
 const secret = authJsCredentialsEnabled
   ? getAuthSecret(env)
-  : createHash("sha256")
-      .update(`${env.NEXT_PUBLIC_APP_NAME}:${env.NEXT_PUBLIC_APP_URL}:journal`)
-      .digest("hex");
+  : randomBytes(32).toString("hex");
 
 const parseTokenDate = (value: unknown) => {
   if (typeof value !== "string") {

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -19,11 +19,11 @@ const secret = authJsCredentialsEnabled
 
 const parseTokenDate = (value: unknown) => {
   if (typeof value !== "string") {
-    return new Date(0);
+    return undefined;
   }
 
   const date = new Date(value);
-  return Number.isNaN(date.getTime()) ? new Date(0) : date;
+  return Number.isNaN(date.getTime()) ? undefined : date;
 };
 
 const authConfig = {
@@ -42,15 +42,18 @@ const authConfig = {
       return token;
     },
     async session({ session, token }) {
+      const createdAt = parseTokenDate(token.createdAt);
+      const updatedAt = parseTokenDate(token.updatedAt);
+
       session.user = {
         ...session.user,
-        createdAt: parseTokenDate(token.createdAt),
+        createdAt,
         displayName:
           typeof token.displayName === "string" ? token.displayName : null,
         email: typeof token.email === "string" ? token.email : "",
         id: typeof token.id === "string" ? token.id : "",
         name: typeof token.displayName === "string" ? token.displayName : null,
-        updatedAt: parseTokenDate(token.updatedAt),
+        updatedAt,
       };
 
       return session;

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -11,100 +11,95 @@ import {
 } from "@/lib/env";
 import { credentialsSchema } from "@/lib/auth/validation";
 
-export const { auth, handlers, signIn, signOut } = NextAuth(() => {
-  const env = readServerEnv();
-  const authJsCredentialsEnabled = usesAuthJsCredentials(env);
-  const secret = authJsCredentialsEnabled
-    ? getAuthSecret(env)
-    : createHash("sha256")
-        .update(`${env.NEXT_PUBLIC_APP_NAME}:${env.NEXT_PUBLIC_APP_URL}:journal`)
-        .digest("hex");
+const env = readServerEnv();
+const authJsCredentialsEnabled = usesAuthJsCredentials(env);
+const secret = authJsCredentialsEnabled
+  ? getAuthSecret(env)
+  : createHash("sha256")
+      .update(`${env.NEXT_PUBLIC_APP_NAME}:${env.NEXT_PUBLIC_APP_URL}:journal`)
+      .digest("hex");
 
-  const parseTokenDate = (value: unknown) => {
-    if (typeof value !== "string") {
-      return new Date(0);
-    }
+const parseTokenDate = (value: unknown) => {
+  if (typeof value !== "string") {
+    return new Date(0);
+  }
 
-    const date = new Date(value);
-    return Number.isNaN(date.getTime()) ? new Date(0) : date;
-  };
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? new Date(0) : date;
+};
 
-  return {
-    callbacks: {
-      async jwt({ token, user }) {
-        if (user) {
-          token.createdAt =
-            user.createdAt instanceof Date
-              ? user.createdAt.toISOString()
-              : undefined;
-          token.displayName = user.displayName ?? null;
-          token.email = user.email;
-          token.id = user.id;
-          token.updatedAt =
-            user.updatedAt instanceof Date
-              ? user.updatedAt.toISOString()
-              : undefined;
-        }
+const authConfig = {
+  callbacks: {
+    async jwt({ token, user }) {
+      if (user) {
+        token.createdAt =
+          user.createdAt instanceof Date ? user.createdAt.toISOString() : undefined;
+        token.displayName = user.displayName ?? null;
+        token.email = user.email;
+        token.id = user.id;
+        token.updatedAt =
+          user.updatedAt instanceof Date ? user.updatedAt.toISOString() : undefined;
+      }
 
-        return token;
-      },
-      async session({ session, token }) {
-        session.user = {
-          ...session.user,
-          createdAt: parseTokenDate(token.createdAt),
-          displayName:
-            typeof token.displayName === "string" ? token.displayName : null,
-          email: typeof token.email === "string" ? token.email : "",
-          id: typeof token.id === "string" ? token.id : "",
-          name:
-            typeof token.displayName === "string" ? token.displayName : null,
-          updatedAt: parseTokenDate(token.updatedAt),
-        };
-
-        return session;
-      },
+      return token;
     },
-    pages: {
-      signIn: "/sign-in",
+    async session({ session, token }) {
+      session.user = {
+        ...session.user,
+        createdAt: parseTokenDate(token.createdAt),
+        displayName:
+          typeof token.displayName === "string" ? token.displayName : null,
+        email: typeof token.email === "string" ? token.email : "",
+        id: typeof token.id === "string" ? token.id : "",
+        name: typeof token.displayName === "string" ? token.displayName : null,
+        updatedAt: parseTokenDate(token.updatedAt),
+      };
+
+      return session;
     },
-    providers: authJsCredentialsEnabled
-      ? [
-          Credentials({
-            credentials: {
-              email: {
-                label: "Email",
-                type: "email",
-              },
-              password: {
-                label: "Password",
-                type: "password",
-              },
+  },
+  pages: {
+    signIn: "/sign-in",
+  },
+  providers: authJsCredentialsEnabled
+    ? [
+        Credentials({
+          credentials: {
+            email: {
+              label: "Email",
+              type: "email",
             },
-            async authorize(credentials) {
-              const result = credentialsSchema.safeParse(credentials);
+            password: {
+              label: "Password",
+              type: "password",
+            },
+          },
+          async authorize(credentials) {
+            const result = credentialsSchema.safeParse(credentials);
 
-              if (!result.success) {
+            if (!result.success) {
+              return null;
+            }
+
+            try {
+              return await authenticateUser(result.data);
+            } catch (error) {
+              if (error instanceof AuthError) {
                 return null;
               }
 
-              try {
-                return await authenticateUser(result.data);
-              } catch (error) {
-                if (error instanceof AuthError) {
-                  return null;
-                }
+              throw error;
+            }
+          },
+          name: "Journal credentials",
+        }),
+      ]
+    : [],
+  secret,
+  session: {
+    strategy: "jwt",
+  },
+  trustHost: shouldTrustAuthHost(env),
+} satisfies NextAuthConfig;
 
-                throw error;
-              }
-            },
-            name: "Journal credentials",
-          }),
-        ]
-      : [],
-    secret,
-    session: {
-      strategy: "jwt",
-    },
-    trustHost: shouldTrustAuthHost(env),
-  } satisfies NextAuthConfig;
-});
+export const { auth, handlers, signIn, signOut } = NextAuth(authConfig);

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,0 +1,110 @@
+import { createHash } from "node:crypto";
+import NextAuth from "next-auth";
+import Credentials from "next-auth/providers/credentials";
+import type { NextAuthConfig } from "next-auth";
+import { AuthError, authenticateUser } from "@/lib/auth/service";
+import {
+  getAuthSecret,
+  readServerEnv,
+  shouldTrustAuthHost,
+  usesAuthJsCredentials,
+} from "@/lib/env";
+import { credentialsSchema } from "@/lib/auth/validation";
+
+export const { auth, handlers, signIn, signOut } = NextAuth(() => {
+  const env = readServerEnv();
+  const authJsCredentialsEnabled = usesAuthJsCredentials(env);
+  const secret = authJsCredentialsEnabled
+    ? getAuthSecret(env)
+    : createHash("sha256")
+        .update(`${env.NEXT_PUBLIC_APP_NAME}:${env.NEXT_PUBLIC_APP_URL}:journal`)
+        .digest("hex");
+
+  const parseTokenDate = (value: unknown) => {
+    if (typeof value !== "string") {
+      return new Date(0);
+    }
+
+    const date = new Date(value);
+    return Number.isNaN(date.getTime()) ? new Date(0) : date;
+  };
+
+  return {
+    callbacks: {
+      async jwt({ token, user }) {
+        if (user) {
+          token.createdAt =
+            user.createdAt instanceof Date
+              ? user.createdAt.toISOString()
+              : undefined;
+          token.displayName = user.displayName ?? null;
+          token.email = user.email;
+          token.id = user.id;
+          token.updatedAt =
+            user.updatedAt instanceof Date
+              ? user.updatedAt.toISOString()
+              : undefined;
+        }
+
+        return token;
+      },
+      async session({ session, token }) {
+        session.user = {
+          ...session.user,
+          createdAt: parseTokenDate(token.createdAt),
+          displayName:
+            typeof token.displayName === "string" ? token.displayName : null,
+          email: typeof token.email === "string" ? token.email : "",
+          id: typeof token.id === "string" ? token.id : "",
+          name:
+            typeof token.displayName === "string" ? token.displayName : null,
+          updatedAt: parseTokenDate(token.updatedAt),
+        };
+
+        return session;
+      },
+    },
+    pages: {
+      signIn: "/sign-in",
+    },
+    providers: authJsCredentialsEnabled
+      ? [
+          Credentials({
+            credentials: {
+              email: {
+                label: "Email",
+                type: "email",
+              },
+              password: {
+                label: "Password",
+                type: "password",
+              },
+            },
+            async authorize(credentials) {
+              const result = credentialsSchema.safeParse(credentials);
+
+              if (!result.success) {
+                return null;
+              }
+
+              try {
+                return await authenticateUser(result.data);
+              } catch (error) {
+                if (error instanceof AuthError) {
+                  return null;
+                }
+
+                throw error;
+              }
+            },
+            name: "Journal credentials",
+          }),
+        ]
+      : [],
+    secret,
+    session: {
+      strategy: "jwt",
+    },
+    trustHost: shouldTrustAuthHost(env),
+  } satisfies NextAuthConfig;
+});

--- a/src/components/auth-page.test.tsx
+++ b/src/components/auth-page.test.tsx
@@ -10,6 +10,9 @@ describe("AuthPage", () => {
         appName="NoemaForge"
         error="invalid-credentials"
         message={undefined}
+        registerAction="/auth/register"
+        signInAction="/auth/sign-in"
+        useAuthJsCredentials={true}
       />,
     );
 
@@ -24,6 +27,11 @@ describe("AuthPage", () => {
     expect(screen.getByRole("heading", { name: "Sign in" })).toBeInTheDocument();
     expect(
       screen.getByText("Check your email and password, then try again."),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /This environment is using the optional Auth\.js credentials session path\./,
+      ),
     ).toBeInTheDocument();
   });
 });

--- a/src/components/auth-page.tsx
+++ b/src/components/auth-page.tsx
@@ -1,7 +1,14 @@
+import type { ComponentProps } from "react";
+
+type FormAction = NonNullable<ComponentProps<"form">["action"]>;
+
 type AuthPageProps = {
   appName: string;
   error?: string;
   message?: string;
+  registerAction: FormAction;
+  signInAction: FormAction;
+  useAuthJsCredentials: boolean;
 };
 
 const authErrorMessages: Record<string, string> = {
@@ -15,7 +22,14 @@ const authMessages: Record<string, string> = {
   "signed-out": "You have been signed out.",
 };
 
-export function AuthPage({ appName, error, message }: AuthPageProps) {
+export function AuthPage({
+  appName,
+  error,
+  message,
+  registerAction,
+  signInAction,
+  useAuthJsCredentials,
+}: AuthPageProps) {
   const notice = (error && authErrorMessages[error]) || (message && authMessages[message]);
 
   return (
@@ -55,10 +69,13 @@ export function AuthPage({ appName, error, message }: AuthPageProps) {
             </h2>
             <p className="text-sm leading-6 text-muted sm:text-base">
               Start a private journal with an email address and password.
+              {useAuthJsCredentials
+                ? " When the optional Auth.js credentials mode is enabled, account creation still uses the same journal user record before handing session management to Auth.js."
+                : ""}
             </p>
           </div>
 
-          <form action="/auth/register" className="mt-6 space-y-4" method="post">
+          <form action={registerAction} className="mt-6 space-y-4" method="post">
             <label className="block space-y-2 text-sm font-medium text-foreground">
               <span>Email</span>
               <input
@@ -96,10 +113,13 @@ export function AuthPage({ appName, error, message }: AuthPageProps) {
             </h2>
             <p className="text-sm leading-6 text-muted sm:text-base">
               Pick up where you left off and search your journal history.
+              {useAuthJsCredentials
+                ? " This environment is using the optional Auth.js credentials session path."
+                : ""}
             </p>
           </div>
 
-          <form action="/auth/sign-in" className="mt-6 space-y-4" method="post">
+          <form action={signInAction} className="mt-6 space-y-4" method="post">
             <label className="block space-y-2 text-sm font-medium text-foreground">
               <span>Email</span>
               <input

--- a/src/components/journal-chrome.tsx
+++ b/src/components/journal-chrome.tsx
@@ -1,10 +1,13 @@
-import type { ReactNode } from "react";
+import type { ComponentProps, ReactNode } from "react";
+
+type FormAction = NonNullable<ComponentProps<"form">["action"]>;
 
 type JournalChromeProps = {
   actions?: ReactNode;
   appName: string;
   children: ReactNode;
   description: string;
+  signOutAction: FormAction;
   title: string;
   userEmail: string;
 };
@@ -14,6 +17,7 @@ export function JournalChrome({
   appName,
   children,
   description,
+  signOutAction,
   title,
   userEmail,
 }: JournalChromeProps) {
@@ -41,7 +45,7 @@ export function JournalChrome({
           <div className="rounded-2xl border border-border bg-slate-50/80 p-4 text-sm text-slate-700">
             <p className="font-medium text-slate-900">Signed in as</p>
             <p className="mt-1 break-all">{userEmail}</p>
-            <form action="/auth/sign-out" className="mt-4" method="post">
+            <form action={signOutAction} className="mt-4" method="post">
               <button
                 className="inline-flex items-center justify-center rounded-full border border-border bg-white px-4 py-2 font-medium text-foreground transition hover:bg-slate-100"
                 type="submit"

--- a/src/components/journal-entry-form.test.tsx
+++ b/src/components/journal-entry-form.test.tsx
@@ -4,7 +4,7 @@ import { render, screen } from "@testing-library/react";
 import { JournalEntryForm } from "@/components/journal-entry-form";
 
 describe("JournalEntryForm", () => {
-  it("syncs the textarea value when the body prop changes", () => {
+  it("shows the new body after a keyed remount", () => {
     const { rerender } = render(
       <JournalEntryForm
         action="/entries/entry-1/update"

--- a/src/components/journal-entry-form.test.tsx
+++ b/src/components/journal-entry-form.test.tsx
@@ -1,0 +1,34 @@
+// @vitest-environment jsdom
+
+import { render, screen } from "@testing-library/react";
+import { JournalEntryForm } from "@/components/journal-entry-form";
+
+describe("JournalEntryForm", () => {
+  it("syncs the textarea value when the body prop changes", () => {
+    const { rerender } = render(
+      <JournalEntryForm
+        action="/entries/entry-1/update"
+        body="First body"
+        description="Edit entry"
+        heading="Edit entry"
+        key="entry-1"
+        submitLabel="Save changes"
+      />,
+    );
+
+    expect(screen.getByLabelText("Entry")).toHaveValue("First body");
+
+    rerender(
+      <JournalEntryForm
+        action="/entries/entry-2/update"
+        body="Second body"
+        description="Edit entry"
+        heading="Edit entry"
+        key="entry-2"
+        submitLabel="Save changes"
+      />,
+    );
+
+    expect(screen.getByLabelText("Entry")).toHaveValue("Second body");
+  });
+});

--- a/src/components/journal-entry-form.tsx
+++ b/src/components/journal-entry-form.tsx
@@ -1,3 +1,7 @@
+"use client";
+
+import { useState } from "react";
+
 type JournalEntryFormProps = {
   action: string;
   body?: string;
@@ -17,6 +21,8 @@ export function JournalEntryForm({
   heading,
   submitLabel,
 }: JournalEntryFormProps) {
+  const [entryBody, setEntryBody] = useState(body ?? "");
+
   return (
     <section className="rounded-3xl border border-border/80 bg-card/95 p-6 shadow-sm sm:p-8">
       <div className="space-y-2">
@@ -39,12 +45,13 @@ export function JournalEntryForm({
           </label>
           <textarea
             className="min-h-56 w-full rounded-3xl border border-border bg-white px-4 py-3 text-base text-foreground outline-none transition focus:border-sky-400 focus:ring-2 focus:ring-sky-200"
-            defaultValue={body}
             id="body"
             maxLength={20_000}
             name="body"
+            onChange={(event) => setEntryBody(event.target.value)}
             placeholder="Type the raw thought, feeling, or note you want to keep."
             required
+            value={entryBody}
           />
           <p className="text-xs leading-5 text-muted">
             Saved entries keep the typed source label plus created and updated

--- a/src/lib/auth/authjs-actions.test.ts
+++ b/src/lib/auth/authjs-actions.test.ts
@@ -1,9 +1,18 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-const { redirect } = vi.hoisted(() => ({
+const { cookieStore, cookies, redirect } = vi.hoisted(() => ({
+  cookieStore: {
+    get: vi.fn(),
+    set: vi.fn(),
+  },
+  cookies: vi.fn(),
   redirect: vi.fn((location: string) => {
     throw new Error(`redirect:${location}`);
   }),
+}));
+
+vi.mock("next/headers", () => ({
+  cookies,
 }));
 
 vi.mock("next/navigation", () => ({
@@ -51,6 +60,21 @@ vi.mock("@/lib/auth/service", () => ({
   registerUser: vi.fn(),
 }));
 
+vi.mock("@/lib/auth/session", () => ({
+  deleteSessionByToken: vi.fn(),
+  getClearedSessionCookie: vi.fn(() => ({
+    expires: new Date(0),
+    httpOnly: true,
+    maxAge: 0,
+    name: "noema_forge_session",
+    path: "/",
+    sameSite: "lax" as const,
+    secure: false,
+    value: "",
+  })),
+  SESSION_COOKIE_NAME: "noema_forge_session",
+}));
+
 import { CredentialsSignin } from "next-auth";
 import {
   registerWithAuthJsCredentials,
@@ -59,6 +83,10 @@ import {
 } from "@/lib/auth/authjs-actions";
 import { signIn, signOut } from "@/auth";
 import { registerUser } from "@/lib/auth/service";
+import {
+  deleteSessionByToken,
+  getClearedSessionCookie,
+} from "@/lib/auth/session";
 
 afterEach(() => {
   vi.resetAllMocks();
@@ -118,8 +146,22 @@ describe("Auth.js credential actions", () => {
   it("routes sign-out through Auth.js when the alternative mode is enabled", async () => {
     vi.stubEnv("AUTH_SIGN_IN_MODE", "authjs-credentials");
     vi.mocked(signOut).mockResolvedValue(undefined as never);
+    cookieStore.get.mockReturnValue({ value: "session-token" });
+    cookies.mockResolvedValue(cookieStore);
 
     await expect(signOutWithAuthJsCredentials(new FormData())).resolves.toBeUndefined();
+    expect(deleteSessionByToken).toHaveBeenCalledWith("session-token");
+    expect(getClearedSessionCookie).toHaveBeenCalledWith();
+    expect(cookieStore.set).toHaveBeenCalledWith({
+      expires: new Date(0),
+      httpOnly: true,
+      maxAge: 0,
+      name: "noema_forge_session",
+      path: "/",
+      sameSite: "lax",
+      secure: false,
+      value: "",
+    });
     expect(signOut).toHaveBeenCalledWith({
       redirectTo: "/sign-in?message=signed-out",
     });

--- a/src/lib/auth/authjs-actions.test.ts
+++ b/src/lib/auth/authjs-actions.test.ts
@@ -1,0 +1,127 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { redirect } = vi.hoisted(() => ({
+  redirect: vi.fn((location: string) => {
+    throw new Error(`redirect:${location}`);
+  }),
+}));
+
+vi.mock("next/navigation", () => ({
+  redirect,
+}));
+
+vi.mock("next-auth", () => {
+  class AuthError extends Error {
+    type: string;
+
+    constructor(type = "AuthError") {
+      super(type);
+      this.name = type;
+      this.type = type;
+    }
+  }
+
+  class CredentialsSignin extends AuthError {
+    constructor() {
+      super("CredentialsSignin");
+    }
+  }
+
+  return {
+    AuthError,
+    CredentialsSignin,
+  };
+});
+
+vi.mock("@/auth", () => ({
+  signIn: vi.fn(),
+  signOut: vi.fn(),
+}));
+
+vi.mock("@/lib/auth/service", () => ({
+  AuthError: class AuthError extends Error {
+    code: string;
+
+    constructor(code: string) {
+      super(code);
+      this.code = code;
+      this.name = "AuthError";
+    }
+  },
+  registerUser: vi.fn(),
+}));
+
+import { CredentialsSignin } from "next-auth";
+import {
+  registerWithAuthJsCredentials,
+  signInWithAuthJsCredentials,
+  signOutWithAuthJsCredentials,
+} from "@/lib/auth/authjs-actions";
+import { signIn, signOut } from "@/auth";
+import { registerUser } from "@/lib/auth/service";
+
+afterEach(() => {
+  vi.resetAllMocks();
+  vi.unstubAllEnvs();
+});
+
+describe("Auth.js credential actions", () => {
+  it("passes validated credentials to Auth.js sign-in", async () => {
+    vi.stubEnv("AUTH_SIGN_IN_MODE", "authjs-credentials");
+    vi.mocked(signIn).mockResolvedValue(undefined as never);
+
+    const formData = new FormData();
+    formData.set("email", "USER@example.com");
+    formData.set("password", "journal-pass-123");
+
+    await expect(signInWithAuthJsCredentials(formData)).resolves.toBeUndefined();
+    expect(signIn).toHaveBeenCalledWith("credentials", {
+      email: "user@example.com",
+      password: "journal-pass-123",
+      redirectTo: "/",
+    });
+  });
+
+  it("redirects invalid credentials back to sign-in", async () => {
+    vi.stubEnv("AUTH_SIGN_IN_MODE", "authjs-credentials");
+    vi.mocked(signIn).mockRejectedValue(new CredentialsSignin());
+
+    const formData = new FormData();
+    formData.set("email", "user@example.com");
+    formData.set("password", "journal-pass-123");
+
+    await expect(signInWithAuthJsCredentials(formData)).rejects.toThrow(
+      "redirect:/sign-in?error=invalid-credentials",
+    );
+  });
+
+  it("registers the journal user before delegating the session to Auth.js", async () => {
+    vi.stubEnv("AUTH_SIGN_IN_MODE", "authjs-credentials");
+    vi.mocked(signIn).mockResolvedValue(undefined as never);
+
+    const formData = new FormData();
+    formData.set("email", "user@example.com");
+    formData.set("password", "journal-pass-123");
+
+    await expect(registerWithAuthJsCredentials(formData)).resolves.toBeUndefined();
+    expect(registerUser).toHaveBeenCalledWith({
+      email: "user@example.com",
+      password: "journal-pass-123",
+    });
+    expect(signIn).toHaveBeenCalledWith("credentials", {
+      email: "user@example.com",
+      password: "journal-pass-123",
+      redirectTo: "/",
+    });
+  });
+
+  it("routes sign-out through Auth.js when the alternative mode is enabled", async () => {
+    vi.stubEnv("AUTH_SIGN_IN_MODE", "authjs-credentials");
+    vi.mocked(signOut).mockResolvedValue(undefined as never);
+
+    await expect(signOutWithAuthJsCredentials(new FormData())).resolves.toBeUndefined();
+    expect(signOut).toHaveBeenCalledWith({
+      redirectTo: "/sign-in?message=signed-out",
+    });
+  });
+});

--- a/src/lib/auth/authjs-actions.ts
+++ b/src/lib/auth/authjs-actions.ts
@@ -1,0 +1,88 @@
+"use server";
+
+import { redirect } from "next/navigation";
+import { AuthError as NextAuthError } from "next-auth";
+import { signIn, signOut } from "@/auth";
+import { AuthError, registerUser } from "@/lib/auth/service";
+import { credentialsSchema, type CredentialsInput } from "@/lib/auth/validation";
+import { usesAuthJsCredentials } from "@/lib/env";
+
+function redirectToAuthError(code: string) {
+  redirect(`/sign-in?error=${code}`);
+}
+
+function parseCredentials(formData: FormData): CredentialsInput {
+  const result = credentialsSchema.safeParse({
+    email: String(formData.get("email") ?? ""),
+    password: String(formData.get("password") ?? ""),
+  });
+
+  if (!result.success) {
+    redirectToAuthError("invalid-input");
+    throw new Error("unreachable");
+  }
+
+  return result.data;
+}
+
+function assertAuthJsCredentialsEnabled() {
+  if (!usesAuthJsCredentials()) {
+    throw new Error(
+      "Auth.js credentials actions are only available when AUTH_SIGN_IN_MODE=authjs-credentials.",
+    );
+  }
+}
+
+async function signInWithCredentials(email: string, password: string) {
+  try {
+    await signIn("credentials", {
+      email,
+      password,
+      redirectTo: "/",
+    });
+  } catch (error) {
+    if (
+      error instanceof NextAuthError &&
+      error.type === "CredentialsSignin"
+    ) {
+      redirectToAuthError("invalid-credentials");
+    }
+
+    throw error;
+  }
+}
+
+export async function registerWithAuthJsCredentials(formData: FormData) {
+  assertAuthJsCredentialsEnabled();
+
+  const credentials = parseCredentials(formData);
+
+  try {
+    await registerUser(credentials);
+  } catch (error) {
+    if (error instanceof AuthError) {
+      redirectToAuthError(error.code);
+    }
+
+    throw error;
+  }
+
+  await signInWithCredentials(credentials.email, credentials.password);
+}
+
+export async function signInWithAuthJsCredentials(formData: FormData) {
+  assertAuthJsCredentialsEnabled();
+
+  const credentials = parseCredentials(formData);
+
+  await signInWithCredentials(credentials.email, credentials.password);
+}
+
+export async function signOutWithAuthJsCredentials(formData: FormData) {
+  assertAuthJsCredentialsEnabled();
+  void formData;
+
+  await signOut({
+    redirectTo: "/sign-in?message=signed-out",
+  });
+}

--- a/src/lib/auth/authjs-actions.ts
+++ b/src/lib/auth/authjs-actions.ts
@@ -1,9 +1,15 @@
 "use server";
 
+import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 import { AuthError as NextAuthError } from "next-auth";
 import { signIn, signOut } from "@/auth";
 import { AuthError, registerUser } from "@/lib/auth/service";
+import {
+  deleteSessionByToken,
+  getClearedSessionCookie,
+  SESSION_COOKIE_NAME,
+} from "@/lib/auth/session";
 import { credentialsSchema, type CredentialsInput } from "@/lib/auth/validation";
 import { usesAuthJsCredentials } from "@/lib/env";
 
@@ -81,6 +87,10 @@ export async function signInWithAuthJsCredentials(formData: FormData) {
 export async function signOutWithAuthJsCredentials(formData: FormData) {
   assertAuthJsCredentialsEnabled();
   void formData;
+
+  const cookieStore = await cookies();
+  await deleteSessionByToken(cookieStore.get(SESSION_COOKIE_NAME)?.value);
+  cookieStore.set(getClearedSessionCookie());
 
   await signOut({
     redirectTo: "/sign-in?message=signed-out",

--- a/src/lib/auth/authjs-session.test.ts
+++ b/src/lib/auth/authjs-session.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import { getAuthUserFromAuthJsSession } from "@/lib/auth/authjs-session";
+
+describe("getAuthUserFromAuthJsSession", () => {
+  it("maps a valid Auth.js session to an AuthUser", () => {
+    expect(
+      getAuthUserFromAuthJsSession({
+        expires: "2030-01-01T00:00:00.000Z",
+        user: {
+          createdAt: "2024-01-01T00:00:00.000Z",
+          displayName: null,
+          email: "user@example.com",
+          id: "user-1",
+          updatedAt: "2024-01-02T00:00:00.000Z",
+        },
+      }),
+    ).toEqual({
+      createdAt: new Date("2024-01-01T00:00:00.000Z"),
+      displayName: null,
+      email: "user@example.com",
+      id: "user-1",
+      updatedAt: new Date("2024-01-02T00:00:00.000Z"),
+    });
+  });
+
+  it("returns null when id or email is missing", () => {
+    expect(
+      getAuthUserFromAuthJsSession({
+        expires: "2030-01-01T00:00:00.000Z",
+        user: {
+          createdAt: "2024-01-01T00:00:00.000Z",
+          displayName: null,
+          email: "",
+          id: "user-1",
+          updatedAt: "2024-01-02T00:00:00.000Z",
+        },
+      }),
+    ).toBeNull();
+
+    expect(
+      getAuthUserFromAuthJsSession({
+        expires: "2030-01-01T00:00:00.000Z",
+        user: {
+          createdAt: "2024-01-01T00:00:00.000Z",
+          displayName: null,
+          email: "user@example.com",
+          id: "",
+          updatedAt: "2024-01-02T00:00:00.000Z",
+        },
+      }),
+    ).toBeNull();
+  });
+
+  it("returns null when createdAt or updatedAt is invalid", () => {
+    expect(
+      getAuthUserFromAuthJsSession({
+        expires: "2030-01-01T00:00:00.000Z",
+        user: {
+          createdAt: "not-a-date",
+          displayName: null,
+          email: "user@example.com",
+          id: "user-1",
+          updatedAt: "2024-01-02T00:00:00.000Z",
+        },
+      }),
+    ).toBeNull();
+
+    expect(
+      getAuthUserFromAuthJsSession({
+        expires: "2030-01-01T00:00:00.000Z",
+        user: {
+          createdAt: "2024-01-01T00:00:00.000Z",
+          displayName: null,
+          email: "user@example.com",
+          id: "user-1",
+          updatedAt: "not-a-date",
+        },
+      }),
+    ).toBeNull();
+  });
+});

--- a/src/lib/auth/authjs-session.test.ts
+++ b/src/lib/auth/authjs-session.test.ts
@@ -1,20 +1,24 @@
+import type { Session } from "next-auth";
 import { describe, expect, it } from "vitest";
 import { getAuthUserFromAuthJsSession } from "@/lib/auth/authjs-session";
 
+function createSession(overrides?: Partial<Session["user"]>): Session {
+  return {
+    expires: "2030-01-01T00:00:00.000Z",
+    user: {
+      createdAt: new Date("2024-01-01T00:00:00.000Z"),
+      displayName: null,
+      email: "user@example.com",
+      id: "user-1",
+      updatedAt: new Date("2024-01-02T00:00:00.000Z"),
+      ...overrides,
+    },
+  };
+}
+
 describe("getAuthUserFromAuthJsSession", () => {
   it("maps a valid Auth.js session to an AuthUser", () => {
-    expect(
-      getAuthUserFromAuthJsSession({
-        expires: "2030-01-01T00:00:00.000Z",
-        user: {
-          createdAt: "2024-01-01T00:00:00.000Z",
-          displayName: null,
-          email: "user@example.com",
-          id: "user-1",
-          updatedAt: "2024-01-02T00:00:00.000Z",
-        },
-      }),
-    ).toEqual({
+    expect(getAuthUserFromAuthJsSession(createSession())).toEqual({
       createdAt: new Date("2024-01-01T00:00:00.000Z"),
       displayName: null,
       email: "user@example.com",
@@ -24,58 +28,25 @@ describe("getAuthUserFromAuthJsSession", () => {
   });
 
   it("returns null when id or email is missing", () => {
-    expect(
-      getAuthUserFromAuthJsSession({
-        expires: "2030-01-01T00:00:00.000Z",
-        user: {
-          createdAt: "2024-01-01T00:00:00.000Z",
-          displayName: null,
-          email: "",
-          id: "user-1",
-          updatedAt: "2024-01-02T00:00:00.000Z",
-        },
-      }),
-    ).toBeNull();
-
-    expect(
-      getAuthUserFromAuthJsSession({
-        expires: "2030-01-01T00:00:00.000Z",
-        user: {
-          createdAt: "2024-01-01T00:00:00.000Z",
-          displayName: null,
-          email: "user@example.com",
-          id: "",
-          updatedAt: "2024-01-02T00:00:00.000Z",
-        },
-      }),
-    ).toBeNull();
+    expect(getAuthUserFromAuthJsSession(createSession({ email: "" }))).toBeNull();
+    expect(getAuthUserFromAuthJsSession(createSession({ id: "" }))).toBeNull();
   });
 
   it("returns null when createdAt or updatedAt is invalid", () => {
     expect(
-      getAuthUserFromAuthJsSession({
-        expires: "2030-01-01T00:00:00.000Z",
-        user: {
-          createdAt: "not-a-date",
-          displayName: null,
-          email: "user@example.com",
-          id: "user-1",
-          updatedAt: "2024-01-02T00:00:00.000Z",
-        },
-      }),
+      getAuthUserFromAuthJsSession(
+        createSession({
+          createdAt: "not-a-date" as unknown as Date,
+        }),
+      ),
     ).toBeNull();
 
     expect(
-      getAuthUserFromAuthJsSession({
-        expires: "2030-01-01T00:00:00.000Z",
-        user: {
-          createdAt: "2024-01-01T00:00:00.000Z",
-          displayName: null,
-          email: "user@example.com",
-          id: "user-1",
-          updatedAt: "not-a-date",
-        },
-      }),
+      getAuthUserFromAuthJsSession(
+        createSession({
+          updatedAt: "not-a-date" as unknown as Date,
+        }),
+      ),
     ).toBeNull();
   });
 });

--- a/src/lib/auth/authjs-session.ts
+++ b/src/lib/auth/authjs-session.ts
@@ -1,0 +1,36 @@
+import type { Session } from "next-auth";
+import type { AuthUser } from "@/lib/auth/service";
+
+function parseSessionDate(value: Date | string | undefined) {
+  if (!value) {
+    return null;
+  }
+
+  const date = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+export function getAuthUserFromAuthJsSession(
+  session: Session | null | undefined,
+): AuthUser | null {
+  const user = session?.user;
+
+  if (!user?.id || !user.email) {
+    return null;
+  }
+
+  const createdAt = parseSessionDate(user.createdAt);
+  const updatedAt = parseSessionDate(user.updatedAt);
+
+  if (!createdAt || !updatedAt) {
+    return null;
+  }
+
+  return {
+    createdAt,
+    displayName: user.displayName ?? null,
+    email: user.email,
+    id: user.id,
+    updatedAt,
+  };
+}

--- a/src/lib/auth/current-user.test.ts
+++ b/src/lib/auth/current-user.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { auth, cookies } = vi.hoisted(() => ({
+  auth: vi.fn(),
+  cookies: vi.fn(),
+}));
+
+const { getUserBySessionToken } = vi.hoisted(() => ({
+  getUserBySessionToken: vi.fn(),
+}));
+
+vi.mock("@/auth", () => ({
+  auth,
+}));
+
+vi.mock("next/headers", () => ({
+  cookies,
+}));
+
+vi.mock("@/lib/auth/session", () => ({
+  getUserBySessionToken,
+  SESSION_COOKIE_NAME: "noema_forge_session",
+}));
+
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.unstubAllEnvs();
+});
+
+describe("getCurrentUser", () => {
+  it("does not consult Auth.js sessions in journal mode", async () => {
+    vi.stubEnv("AUTH_SIGN_IN_MODE", "journal");
+    cookies.mockResolvedValue({
+      get: vi.fn(() => undefined),
+    });
+    vi.mocked(getUserBySessionToken).mockResolvedValue(null);
+
+    const { getCurrentUser } = await import("@/lib/auth/current-user");
+
+    await expect(getCurrentUser()).resolves.toBeNull();
+    expect(auth).not.toHaveBeenCalled();
+  });
+
+  it("falls back to Auth.js sessions when the optional mode is enabled", async () => {
+    vi.stubEnv("AUTH_SIGN_IN_MODE", "authjs-credentials");
+    cookies.mockResolvedValue({
+      get: vi.fn(() => undefined),
+    });
+    vi.mocked(getUserBySessionToken).mockResolvedValue(null);
+    vi.mocked(auth).mockResolvedValue({
+      expires: "2030-01-01T00:00:00.000Z",
+      user: {
+        createdAt: "2024-01-01T00:00:00.000Z",
+        displayName: null,
+        email: "user@example.com",
+        id: "user-1",
+        updatedAt: "2024-01-02T00:00:00.000Z",
+      },
+    });
+
+    const { getCurrentUser } = await import("@/lib/auth/current-user");
+
+    await expect(getCurrentUser()).resolves.toEqual({
+      createdAt: new Date("2024-01-01T00:00:00.000Z"),
+      displayName: null,
+      email: "user@example.com",
+      id: "user-1",
+      updatedAt: new Date("2024-01-02T00:00:00.000Z"),
+    });
+    expect(auth).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/lib/auth/current-user.test.ts
+++ b/src/lib/auth/current-user.test.ts
@@ -69,4 +69,29 @@ describe("getCurrentUser", () => {
     });
     expect(auth).toHaveBeenCalledTimes(1);
   });
+
+  it("prefers the first-party session over Auth.js in credentials mode", async () => {
+    vi.stubEnv("AUTH_SIGN_IN_MODE", "authjs-credentials");
+    cookies.mockResolvedValue({
+      get: vi.fn(() => ({ value: "session-token" })),
+    });
+    vi.mocked(getUserBySessionToken).mockResolvedValue({
+      createdAt: new Date("2024-01-01T00:00:00.000Z"),
+      displayName: null,
+      email: "user@example.com",
+      id: "user-1",
+      updatedAt: new Date("2024-01-02T00:00:00.000Z"),
+    });
+
+    const { getCurrentUser } = await import("@/lib/auth/current-user");
+
+    await expect(getCurrentUser()).resolves.toEqual({
+      createdAt: new Date("2024-01-01T00:00:00.000Z"),
+      displayName: null,
+      email: "user@example.com",
+      id: "user-1",
+      updatedAt: new Date("2024-01-02T00:00:00.000Z"),
+    });
+    expect(auth).not.toHaveBeenCalled();
+  });
 });

--- a/src/lib/auth/current-user.ts
+++ b/src/lib/auth/current-user.ts
@@ -2,6 +2,7 @@ import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 import { auth } from "@/auth";
 import { getAuthUserFromAuthJsSession } from "@/lib/auth/authjs-session";
+import { readServerEnv, usesAuthJsCredentials } from "@/lib/env";
 import { getUserBySessionToken, SESSION_COOKIE_NAME } from "@/lib/auth/session";
 
 export async function getCurrentUser() {
@@ -12,6 +13,10 @@ export async function getCurrentUser() {
 
   if (sessionUser) {
     return sessionUser;
+  }
+
+  if (!usesAuthJsCredentials(readServerEnv())) {
+    return null;
   }
 
   return getAuthUserFromAuthJsSession(await auth());

--- a/src/lib/auth/current-user.ts
+++ b/src/lib/auth/current-user.ts
@@ -1,10 +1,20 @@
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
+import { auth } from "@/auth";
+import { getAuthUserFromAuthJsSession } from "@/lib/auth/authjs-session";
 import { getUserBySessionToken, SESSION_COOKIE_NAME } from "@/lib/auth/session";
 
 export async function getCurrentUser() {
   const cookieStore = await cookies();
-  return getUserBySessionToken(cookieStore.get(SESSION_COOKIE_NAME)?.value);
+  const sessionUser = await getUserBySessionToken(
+    cookieStore.get(SESSION_COOKIE_NAME)?.value,
+  );
+
+  if (sessionUser) {
+    return sessionUser;
+  }
+
+  return getAuthUserFromAuthJsSession(await auth());
 }
 
 export async function requireCurrentUser() {

--- a/src/lib/auth/request.test.ts
+++ b/src/lib/auth/request.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { NextRequest } from "next/server";
 
 const { getUserBySessionToken } = vi.hoisted(() => ({
@@ -12,8 +12,14 @@ vi.mock("@/lib/auth/session", () => ({
 
 import { getRequestUser } from "@/lib/auth/request";
 
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.unstubAllEnvs();
+});
+
 describe("getRequestUser", () => {
   it("maps an Auth.js session attached by the route wrapper", async () => {
+    vi.stubEnv("AUTH_SIGN_IN_MODE", "authjs-credentials");
     vi.mocked(getUserBySessionToken).mockResolvedValue(null);
 
     const request = new NextRequest("http://127.0.0.1:3000/entries", {
@@ -49,5 +55,38 @@ describe("getRequestUser", () => {
       id: "user-1",
       updatedAt: new Date("2024-01-02T00:00:00.000Z"),
     });
+  });
+
+  it("ignores an attached Auth.js session when the optional mode is disabled", async () => {
+    vi.stubEnv("AUTH_SIGN_IN_MODE", "journal");
+    vi.mocked(getUserBySessionToken).mockResolvedValue(null);
+
+    const request = new NextRequest("http://127.0.0.1:3000/entries", {
+      method: "POST",
+    }) as NextRequest & {
+      auth: {
+        expires: string;
+        user: {
+          createdAt: Date;
+          displayName: string | null;
+          email: string;
+          id: string;
+          updatedAt: Date;
+        };
+      };
+    };
+
+    request.auth = {
+      expires: "2030-01-01T00:00:00.000Z",
+      user: {
+        createdAt: new Date("2024-01-01T00:00:00.000Z"),
+        displayName: null,
+        email: "user@example.com",
+        id: "user-1",
+        updatedAt: new Date("2024-01-02T00:00:00.000Z"),
+      },
+    };
+
+    await expect(getRequestUser(request)).resolves.toBeNull();
   });
 });

--- a/src/lib/auth/request.test.ts
+++ b/src/lib/auth/request.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+const { getUserBySessionToken } = vi.hoisted(() => ({
+  getUserBySessionToken: vi.fn(),
+}));
+
+vi.mock("@/lib/auth/session", () => ({
+  getUserBySessionToken,
+  SESSION_COOKIE_NAME: "noema_forge_session",
+}));
+
+import { getRequestUser } from "@/lib/auth/request";
+
+describe("getRequestUser", () => {
+  it("maps an Auth.js session attached by the route wrapper", async () => {
+    vi.mocked(getUserBySessionToken).mockResolvedValue(null);
+
+    const request = new NextRequest("http://127.0.0.1:3000/entries", {
+      method: "POST",
+    }) as NextRequest & {
+      auth: {
+        expires: string;
+        user: {
+          createdAt: Date;
+          displayName: string | null;
+          email: string;
+          id: string;
+          updatedAt: Date;
+        };
+      };
+    };
+
+    request.auth = {
+      expires: "2030-01-01T00:00:00.000Z",
+      user: {
+        createdAt: new Date("2024-01-01T00:00:00.000Z"),
+        displayName: null,
+        email: "user@example.com",
+        id: "user-1",
+        updatedAt: new Date("2024-01-02T00:00:00.000Z"),
+      },
+    };
+
+    await expect(getRequestUser(request)).resolves.toEqual({
+      createdAt: new Date("2024-01-01T00:00:00.000Z"),
+      displayName: null,
+      email: "user@example.com",
+      id: "user-1",
+      updatedAt: new Date("2024-01-02T00:00:00.000Z"),
+    });
+  });
+});

--- a/src/lib/auth/request.test.ts
+++ b/src/lib/auth/request.test.ts
@@ -89,4 +89,52 @@ describe("getRequestUser", () => {
 
     await expect(getRequestUser(request)).resolves.toBeNull();
   });
+
+  it("prefers the first-party session over an attached Auth.js session", async () => {
+    vi.stubEnv("AUTH_SIGN_IN_MODE", "authjs-credentials");
+    vi.mocked(getUserBySessionToken).mockResolvedValue({
+      createdAt: new Date("2024-01-01T00:00:00.000Z"),
+      displayName: null,
+      email: "user@example.com",
+      id: "user-1",
+      updatedAt: new Date("2024-01-02T00:00:00.000Z"),
+    });
+
+    const request = new NextRequest("http://127.0.0.1:3000/entries", {
+      headers: {
+        cookie: "noema_forge_session=session-token",
+      },
+      method: "POST",
+    }) as NextRequest & {
+      auth: {
+        expires: string;
+        user: {
+          createdAt: Date;
+          displayName: string | null;
+          email: string;
+          id: string;
+          updatedAt: Date;
+        };
+      };
+    };
+
+    request.auth = {
+      expires: "2030-01-01T00:00:00.000Z",
+      user: {
+        createdAt: new Date("2030-01-01T00:00:00.000Z"),
+        displayName: "Different user",
+        email: "other@example.com",
+        id: "user-2",
+        updatedAt: new Date("2030-01-02T00:00:00.000Z"),
+      },
+    };
+
+    await expect(getRequestUser(request)).resolves.toEqual({
+      createdAt: new Date("2024-01-01T00:00:00.000Z"),
+      displayName: null,
+      email: "user@example.com",
+      id: "user-1",
+      updatedAt: new Date("2024-01-02T00:00:00.000Z"),
+    });
+  });
 });

--- a/src/lib/auth/request.ts
+++ b/src/lib/auth/request.ts
@@ -1,10 +1,18 @@
 import type { NextRequest } from "next/server";
+import type { NextAuthRequest } from "next-auth";
+import { getAuthUserFromAuthJsSession } from "@/lib/auth/authjs-session";
 import { getUserBySessionToken, SESSION_COOKIE_NAME } from "@/lib/auth/session";
 
 export function getSessionTokenFromRequest(request: NextRequest) {
   return request.cookies.get(SESSION_COOKIE_NAME)?.value;
 }
 
-export async function getRequestUser(request: NextRequest) {
-  return getUserBySessionToken(getSessionTokenFromRequest(request));
+export async function getRequestUser(request: NextRequest | NextAuthRequest) {
+  const sessionUser = await getUserBySessionToken(getSessionTokenFromRequest(request));
+
+  if (sessionUser) {
+    return sessionUser;
+  }
+
+  return "auth" in request ? getAuthUserFromAuthJsSession(request.auth) : null;
 }

--- a/src/lib/auth/request.ts
+++ b/src/lib/auth/request.ts
@@ -1,6 +1,7 @@
 import type { NextRequest } from "next/server";
 import type { NextAuthRequest } from "next-auth";
 import { getAuthUserFromAuthJsSession } from "@/lib/auth/authjs-session";
+import { readServerEnv, usesAuthJsCredentials } from "@/lib/env";
 import { getUserBySessionToken, SESSION_COOKIE_NAME } from "@/lib/auth/session";
 
 export function getSessionTokenFromRequest(request: NextRequest) {
@@ -12,6 +13,10 @@ export async function getRequestUser(request: NextRequest | NextAuthRequest) {
 
   if (sessionUser) {
     return sessionUser;
+  }
+
+  if (!usesAuthJsCredentials(readServerEnv())) {
+    return null;
   }
 
   return "auth" in request ? getAuthUserFromAuthJsSession(request.auth) : null;

--- a/src/lib/env.test.ts
+++ b/src/lib/env.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { getAuthSecret, readServerEnv, shouldTrustAuthHost, usesAuthJsCredentials } from "@/lib/env";
+
+describe("auth environment helpers", () => {
+  it("defaults to the first-party journal auth flow and trusts localhost", () => {
+    const env = readServerEnv({
+      NEXT_PUBLIC_APP_URL: "http://127.0.0.1:3000",
+    });
+
+    expect(env.AUTH_SIGN_IN_MODE).toBe("journal");
+    expect(usesAuthJsCredentials(env)).toBe(false);
+    expect(shouldTrustAuthHost(env)).toBe(true);
+  });
+
+  it("parses the optional Auth.js credentials mode", () => {
+    const env = readServerEnv({
+      AUTH_SECRET: "test-secret",
+      AUTH_SIGN_IN_MODE: "authjs-credentials",
+      AUTH_TRUST_HOST: "true",
+      NEXT_PUBLIC_APP_URL: "http://127.0.0.1:3000",
+    });
+
+    expect(usesAuthJsCredentials(env)).toBe(true);
+    expect(shouldTrustAuthHost(env)).toBe(true);
+    expect(getAuthSecret(env)).toBe("test-secret");
+  });
+
+  it("requires an Auth.js secret when the alternative mode is enabled", () => {
+    const env = readServerEnv({
+      AUTH_SIGN_IN_MODE: "authjs-credentials",
+      NEXT_PUBLIC_APP_URL: "http://127.0.0.1:3000",
+    });
+
+    expect(() => getAuthSecret(env)).toThrow(
+      "AUTH_SECRET is required when AUTH_SIGN_IN_MODE=authjs-credentials.",
+    );
+  });
+});

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -15,6 +15,15 @@ const textWithDefault = (defaultValue: string) =>
   z.preprocess(coerceOptional, z.string().default(defaultValue));
 
 const serverEnvSchema = z.object({
+  AUTH_SECRET: optionalText,
+  AUTH_SIGN_IN_MODE: z.preprocess(
+    coerceOptional,
+    z.enum(["journal", "authjs-credentials"]).default("journal"),
+  ),
+  AUTH_TRUST_HOST: z.preprocess(
+    coerceOptional,
+    z.enum(["true", "false"]).default("false"),
+  ),
   DATABASE_URL: optionalUrl,
   DATABASE_URL_NON_POOLING: optionalUrl,
   NEXT_PUBLIC_APP_NAME: textWithDefault("NoemaForge"),
@@ -46,6 +55,30 @@ export type StorageConfig = {
 
 export function readServerEnv(source: NodeJS.ProcessEnv = process.env): ServerEnv {
   return serverEnvSchema.parse(source);
+}
+
+export function usesAuthJsCredentials(env: ServerEnv = readServerEnv()) {
+  return env.AUTH_SIGN_IN_MODE === "authjs-credentials";
+}
+
+export function shouldTrustAuthHost(env: ServerEnv = readServerEnv()) {
+  if (env.AUTH_TRUST_HOST === "true") {
+    return true;
+  }
+
+  return ["127.0.0.1", "::1", "localhost"].includes(
+    new URL(env.NEXT_PUBLIC_APP_URL).hostname,
+  );
+}
+
+export function getAuthSecret(env: ServerEnv = readServerEnv()) {
+  if (!env.AUTH_SECRET) {
+    throw new Error(
+      "AUTH_SECRET is required when AUTH_SIGN_IN_MODE=authjs-credentials.",
+    );
+  }
+
+  return env.AUTH_SECRET;
 }
 
 export function hasDatabaseConfig(env: ServerEnv = readServerEnv()) {

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -4,20 +4,20 @@ import type { JWT as DefaultJWT } from "next-auth/jwt";
 declare module "next-auth" {
   interface Session {
     user: DefaultSession["user"] & {
-      createdAt: Date;
+      createdAt?: Date;
       displayName: string | null;
       email: string;
       id: string;
-      updatedAt: Date;
+      updatedAt?: Date;
     };
   }
 
   interface User {
-    createdAt: Date;
+    createdAt?: Date;
     displayName: string | null;
     email: string;
     id: string;
-    updatedAt: Date;
+    updatedAt?: Date;
   }
 }
 

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -1,0 +1,32 @@
+import type { DefaultSession } from "next-auth";
+import type { JWT as DefaultJWT } from "next-auth/jwt";
+
+declare module "next-auth" {
+  interface Session {
+    user: DefaultSession["user"] & {
+      createdAt: Date;
+      displayName: string | null;
+      email: string;
+      id: string;
+      updatedAt: Date;
+    };
+  }
+
+  interface User {
+    createdAt: Date;
+    displayName: string | null;
+    email: string;
+    id: string;
+    updatedAt: Date;
+  }
+}
+
+declare module "next-auth/jwt" {
+  interface JWT extends DefaultJWT {
+    createdAt?: string;
+    displayName?: string | null;
+    email?: string;
+    id?: string;
+    updatedAt?: string;
+  }
+}


### PR DESCRIPTION
## Summary
- add an optional Auth.js credentials sign-in path behind explicit env configuration
- keep the default journal auth/session flow intact while allowing journal surfaces to accept either session source
- document the auth mode boundary and cover the new flow with unit tests

## Validation
- npm run lint
- npm run build
- npm run test:unit
- npm run test:e2e

Closes #15