### PR TITLE
feat(capture): Add multimodal journal capture #19

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "postgres": "3.4.9",
         "react": "19.2.5",
         "react-dom": "19.2.5",
+        "tesseract.js": "7.0.0",
         "zod": "4.3.6"
       },
       "devDependencies": {
@@ -5313,6 +5314,12 @@
         "require-from-string": "^2.0.2"
       }
     },
+    "node_modules/bmp-js": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/bmp-js/-/bmp-js-0.1.0.tgz",
+      "integrity": "sha512-vHdS19CnY3hwiNdkaqk93DvjVLfbEcI8mys4UjuWrlX1haDmroo8o4xCzh4wD6DGV6HxRCyauwhHRqMTfERtjw==",
+      "license": "MIT"
+    },
     "node_modules/bowser": {
       "version": "2.14.1",
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
@@ -7602,6 +7609,12 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
+    "node_modules/idb-keyval": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.2.2.tgz",
+      "integrity": "sha512-yjD9nARJ/jb1g+CvD0tlhUHOrJ9Sy0P8T9MF3YaLlHnSRpwPfpTX0XIvpmw3gAJUmEu3FiICLBDPXVwyEvrleg==",
+      "license": "Apache-2.0"
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -8039,6 +8052,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/is-url": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
+      "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
+      "license": "MIT"
     },
     "node_modules/is-weakmap": {
       "version": "2.0.2",
@@ -8891,6 +8910,48 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.37",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.37.tgz",
@@ -9040,6 +9101,15 @@
         "https://opencollective.com/debug"
       ],
       "license": "MIT"
+    },
+    "node_modules/opencollective-postinstall": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.3.tgz",
+      "integrity": "sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q==",
+      "license": "MIT",
+      "bin": {
+        "opencollective-postinstall": "index.js"
+      }
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -9458,6 +9528,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "license": "MIT"
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.4",
@@ -10202,6 +10278,30 @@
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       }
+    },
+    "node_modules/tesseract.js": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/tesseract.js/-/tesseract.js-7.0.0.tgz",
+      "integrity": "sha512-exPBkd+z+wM1BuMkx/Bjv43OeLBxhL5kKWsz/9JY+DXcXdiBjiAch0V49QR3oAJqCaL5qURE0vx9Eo+G5YE7mA==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bmp-js": "^0.1.0",
+        "idb-keyval": "^6.2.0",
+        "is-url": "^1.2.4",
+        "node-fetch": "^2.6.9",
+        "opencollective-postinstall": "^2.0.3",
+        "regenerator-runtime": "^0.13.3",
+        "tesseract.js-core": "^7.0.0",
+        "wasm-feature-detect": "^1.8.0",
+        "zlibjs": "^0.3.1"
+      }
+    },
+    "node_modules/tesseract.js-core": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/tesseract.js-core/-/tesseract.js-core-7.0.0.tgz",
+      "integrity": "sha512-WnNH518NzmbSq9zgTPeoF8c+xmilS8rFIl1YKbk/ptuuc7p6cLNELNuPAzcmsYw450ca6bLa8j3t0VAtq435Vw==",
+      "license": "Apache-2.0"
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
@@ -11364,6 +11464,12 @@
         "node": ">=18"
       }
     },
+    "node_modules/wasm-feature-detect": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/wasm-feature-detect/-/wasm-feature-detect-1.8.0.tgz",
+      "integrity": "sha512-zksaLKM2fVlnB5jQQDqKXXwYHLQUVH9es+5TOOHwGOVJOCeRBCiPjwSg+3tN2AdTCzjgli4jijCH290kXb/zWQ==",
+      "license": "Apache-2.0"
+    },
     "node_modules/webidl-conversions": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
@@ -11566,6 +11672,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zlibjs": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/zlibjs/-/zlibjs-0.3.1.tgz",
+      "integrity": "sha512-+J9RrgTKOmlxFSDHo0pI1xM6BLVUv+o0ZT9ANtCxGkjIVCCUdx9alUF8Gm+dGLKbkkkidWIHFDZHDMpfITt4+w==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/zod": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "postgres": "3.4.9",
     "react": "19.2.5",
     "react-dom": "19.2.5",
+    "tesseract.js": "7.0.0",
     "zod": "4.3.6"
   },
   "devDependencies": {

--- a/src/app/entries/[entryId]/edit/page.tsx
+++ b/src/app/entries/[entryId]/edit/page.tsx
@@ -45,7 +45,7 @@ export default async function EditEntryPage({
         </a>
       }
       appName={env.NEXT_PUBLIC_APP_NAME}
-      description="Refine the text while keeping the original entry history private and searchable."
+      description="Refine the text while keeping the original capture source and archive history private and searchable."
       signOutAction={signOutAction}
       title="Edit entry"
       userEmail={user.email}
@@ -54,7 +54,7 @@ export default async function EditEntryPage({
         action={`/entries/${entry.id}/update`}
         body={entry.body}
         cancelHref={`/entries/${entry.id}`}
-        description="Update the typed text and keep the entry in the same searchable archive."
+        description="Update the journal text while keeping the original capture source in the same searchable archive."
         error={error ? editErrorMessages[error] : undefined}
         heading="Revise this entry"
         key={entry.id}

--- a/src/app/entries/[entryId]/page.tsx
+++ b/src/app/entries/[entryId]/page.tsx
@@ -55,7 +55,7 @@ export default async function EntryDetailPage({
         </>
       }
       appName={env.NEXT_PUBLIC_APP_NAME}
-      description="Review the full text and metadata for a typed journal entry."
+      description="Review the full text and metadata for a journal entry from any capture mode."
       signOutAction={signOutAction}
       title="Entry detail"
       userEmail={user.email}

--- a/src/app/entries/route.test.ts
+++ b/src/app/entries/route.test.ts
@@ -82,7 +82,45 @@ describe("POST /entries", () => {
     expect(location.pathname).toBe("/entries/entry-1");
     expect(location.search).toBe("?message=created");
     expect(createJournalEntry).toHaveBeenCalledWith(
-      { body: "A typed entry" },
+      { body: "A typed entry", source: undefined },
+      "user-1",
+    );
+  });
+
+  it("passes the selected capture source when present", async () => {
+    vi.mocked(getRequestUser).mockResolvedValue({
+      createdAt: new Date(),
+      displayName: null,
+      email: "user@example.com",
+      id: "user-1",
+      updatedAt: new Date(),
+    });
+    vi.mocked(createJournalEntry).mockResolvedValue({
+      body: "A dictated entry",
+      createdAt: new Date(),
+      id: "entry-2",
+      source: "voice",
+      updatedAt: new Date(),
+      userId: "user-1",
+    });
+
+    const formData = new FormData();
+    formData.set("body", "A dictated entry");
+    formData.set("source", "voice");
+
+    const response = await POST(
+      new NextRequest("http://127.0.0.1:3000/entries", {
+        body: formData,
+        method: "POST",
+      }),
+    );
+    const location = new URL(response.headers.get("location") ?? "");
+
+    expect(response.status).toBe(303);
+    expect(location.pathname).toBe("/entries/entry-2");
+    expect(location.search).toBe("?message=created");
+    expect(createJournalEntry).toHaveBeenCalledWith(
+      { body: "A dictated entry", source: "voice" },
       "user-1",
     );
   });

--- a/src/app/entries/route.ts
+++ b/src/app/entries/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import type { NextAuthRequest } from "next-auth";
 import { auth } from "@/auth";
 import { getRequestUser } from "@/lib/auth/request";
+import { isCaptureSource } from "@/lib/journal/capture-source";
 import { JournalError, createJournalEntry } from "@/lib/journal/service";
 import { getRequestUrl } from "@/lib/request-url";
 
@@ -13,11 +14,14 @@ async function handlePost(request: NextAuthRequest) {
   }
 
   const formData = await request.formData();
+  const source = formData.get("source");
 
   try {
     const entry = await createJournalEntry(
       {
         body: String(formData.get("body") ?? ""),
+        source:
+          typeof source === "string" && isCaptureSource(source) ? source : undefined,
       },
       user.id,
     );

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,7 +3,7 @@ import "./globals.css";
 
 export const metadata: Metadata = {
   title: "NoemaForge",
-  description: "Private typed capture and journal history for NoemaForge.",
+  description: "Private multimodal capture and journal history for NoemaForge.",
 };
 
 export default function RootLayout({

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,7 @@
 import { EntryMetadata } from "@/components/entry-metadata";
 import { JournalChrome } from "@/components/journal-chrome";
 import { signOutWithAuthJsCredentials } from "@/lib/auth/authjs-actions";
-import { JournalEntryForm } from "@/components/journal-entry-form";
+import { JournalCaptureForm } from "@/components/journal-capture-form";
 import { requireCurrentUser } from "@/lib/auth/current-user";
 import { readServerEnv, usesAuthJsCredentials } from "@/lib/env";
 import { excerptText } from "@/lib/formatting";
@@ -34,18 +34,18 @@ export default async function Home({ searchParams }: HomePageProps) {
   return (
     <JournalChrome
       appName={env.NEXT_PUBLIC_APP_NAME}
-      description="Capture typed thoughts, edit them later, and search the archive without leaving your private journal."
+      description="Capture typed thoughts, voice dictation, or handwriting OCR and keep every entry in one private, searchable journal."
       signOutAction={signOutAction}
       title="Journal history"
       userEmail={user.email}
     >
       <div className="grid gap-6 xl:grid-cols-[minmax(0,0.92fr)_minmax(0,1.08fr)]">
-        <JournalEntryForm
+        <JournalCaptureForm
           action="/entries"
           key="new-entry"
-          description="Typing is the default capture path for this slice. Save raw thoughts here, then review or edit them from the archive."
+          description="Type directly, dictate with your browser, or upload a handwritten note image. Review the extracted text before saving it into the archive."
           error={error ? homeErrorMessages[error] : undefined}
-          heading="New typed entry"
+          heading="New journal entry"
           submitLabel="Save entry"
         />
 
@@ -80,12 +80,12 @@ export default async function Home({ searchParams }: HomePageProps) {
 
           <div className="mt-6 space-y-4">
             {entries.length === 0 ? (
-              <div className="rounded-3xl border border-dashed border-border bg-slate-50/70 px-5 py-8 text-sm leading-6 text-muted">
-                {query
-                  ? `No entries match "${query}" yet.`
-                  : "No entries yet. Save your first typed capture to start the archive."}
-              </div>
-            ) : (
+                <div className="rounded-3xl border border-dashed border-border bg-slate-50/70 px-5 py-8 text-sm leading-6 text-muted">
+                  {query
+                    ? `No entries match "${query}" yet.`
+                    : "No entries yet. Save your first capture to start the archive."}
+                </div>
+              ) : (
               entries.map((entry) => (
                 <article
                   key={entry.id}

--- a/src/components/auth-page.test.tsx
+++ b/src/components/auth-page.test.tsx
@@ -18,7 +18,7 @@ describe("AuthPage", () => {
 
     expect(
       screen.getByRole("heading", {
-        name: "Private typed capture, ready when you are.",
+        name: "Private multimodal capture, ready when you are.",
       }),
     ).toBeInTheDocument();
     expect(

--- a/src/components/auth-page.tsx
+++ b/src/components/auth-page.tsx
@@ -40,11 +40,12 @@ export function AuthPage({
             {appName}
           </p>
           <h1 className="text-4xl font-semibold tracking-tight text-foreground sm:text-5xl">
-            Private typed capture, ready when you are.
+            Private multimodal capture, ready when you are.
           </h1>
           <p className="max-w-2xl text-base leading-7 text-muted sm:text-lg">
             Create a journal account or sign in to keep a private archive of typed
-            entries, searchable history, and clear edit flows.
+            notes, voice dictation, handwriting OCR, searchable history, and clear
+            edit flows.
           </p>
         </div>
       </section>

--- a/src/components/entry-metadata.tsx
+++ b/src/components/entry-metadata.tsx
@@ -1,5 +1,6 @@
 import type { JournalEntryRecord } from "@/lib/journal/service";
 import { formatTimestamp } from "@/lib/formatting";
+import { formatCaptureSource } from "@/lib/journal/capture-source";
 
 type EntryMetadataProps = Pick<JournalEntryRecord, "createdAt" | "source" | "updatedAt">;
 
@@ -24,7 +25,7 @@ export function EntryMetadata({
       </div>
       <div className="rounded-2xl border border-border bg-slate-50/70 p-3">
         <dt className="font-medium text-foreground">Source</dt>
-        <dd className="mt-1 capitalize">{source}</dd>
+        <dd className="mt-1">{formatCaptureSource(source)}</dd>
       </div>
     </dl>
   );

--- a/src/components/journal-capture-form.test.tsx
+++ b/src/components/journal-capture-form.test.tsx
@@ -1,0 +1,98 @@
+// @vitest-environment jsdom
+
+import { act, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { vi } from "vitest";
+import { JournalCaptureForm } from "@/components/journal-capture-form";
+
+function getSourceInput() {
+  const input = document.querySelector('input[name="source"]');
+
+  if (!(input instanceof HTMLInputElement)) {
+    throw new Error("Expected hidden source input to be present.");
+  }
+
+  return input;
+}
+
+function createRecognitionStub() {
+  return {
+    continuous: false,
+    interimResults: false,
+    lang: "",
+    onend: null as (() => void) | null,
+    onerror: null as ((event: { error: string }) => void) | null,
+    onresult: null as ((event: { results: ArrayLike<{ 0: { transcript: string }; length: number }> }) => void) | null,
+    start: vi.fn(),
+    stop: vi.fn(),
+  };
+}
+
+describe("JournalCaptureForm", () => {
+  it("captures dictated text into the shared editor", async () => {
+    const recognition = createRecognitionStub();
+    const user = userEvent.setup();
+
+    render(
+      <JournalCaptureForm
+        action="/entries"
+        createSpeechRecognition={() => recognition}
+        description="Create a new entry"
+        heading="New journal entry"
+        submitLabel="Save entry"
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Voice dictation" }));
+    await user.click(screen.getByRole("button", { name: "Start dictation" }));
+
+    expect(getSourceInput()).toHaveValue("voice");
+    expect(recognition.start).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      recognition.onresult?.({
+        results: [{ 0: { transcript: "Spoken draft" }, length: 1 }],
+      });
+      recognition.onend?.();
+    });
+
+    expect(screen.getByLabelText("Entry")).toHaveValue("Spoken draft");
+    expect(
+      screen.getByText("Dictation stopped. Review and edit the transcript before saving."),
+    ).toBeInTheDocument();
+  });
+
+  it("imports OCR text into the shared editor", async () => {
+    const extractImageText = vi
+      .fn<(file: File, onProgress: (progress: number) => void) => Promise<string>>()
+      .mockImplementation(async (_file, onProgress) => {
+        onProgress(0.6);
+        return "Scanned line\n\nsecond line";
+      });
+    const user = userEvent.setup();
+
+    render(
+      <JournalCaptureForm
+        action="/entries"
+        description="Create a new entry"
+        extractImageText={extractImageText}
+        heading="New journal entry"
+        submitLabel="Save entry"
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Handwriting OCR" }));
+    await user.upload(
+      screen.getByLabelText("Handwritten note image"),
+      new File(["note image"], "note.png", { type: "image/png" }),
+    );
+
+    await waitFor(() =>
+      expect(screen.getByLabelText("Entry")).toHaveValue("Scanned line\n\nsecond line"),
+    );
+
+    expect(getSourceInput()).toHaveValue("ocr");
+    expect(extractImageText).toHaveBeenCalledTimes(1);
+    expect(screen.getByText(/Imported text from note\.png\./)).toBeInTheDocument();
+  });
+});

--- a/src/components/journal-capture-form.test.tsx
+++ b/src/components/journal-capture-form.test.tsx
@@ -62,6 +62,32 @@ describe("JournalCaptureForm", () => {
     ).toBeInTheDocument();
   });
 
+  it("stops active dictation when switching away from voice mode", async () => {
+    const recognition = createRecognitionStub();
+    const user = userEvent.setup();
+
+    render(
+      <JournalCaptureForm
+        action="/entries"
+        createSpeechRecognition={() => recognition}
+        description="Create a new entry"
+        heading="New journal entry"
+        submitLabel="Save entry"
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Voice dictation" }));
+    await user.click(screen.getByRole("button", { name: "Start dictation" }));
+
+    expect(screen.getByLabelText("Entry")).toHaveAttribute("readonly");
+
+    await user.click(screen.getByRole("button", { name: "Typed" }));
+
+    expect(recognition.stop).toHaveBeenCalledTimes(1);
+    expect(getSourceInput()).toHaveValue("typed");
+    expect(screen.getByLabelText("Entry")).not.toHaveAttribute("readonly");
+  });
+
   it("imports OCR text into the shared editor", async () => {
     const extractImageText = vi
       .fn<(file: File, onProgress: (progress: number) => void) => Promise<string>>()

--- a/src/components/journal-capture-form.test.tsx
+++ b/src/components/journal-capture-form.test.tsx
@@ -62,6 +62,30 @@ describe("JournalCaptureForm", () => {
     ).toBeInTheDocument();
   });
 
+  it("falls back to typed source when dictation is unavailable", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <JournalCaptureForm
+        action="/entries"
+        createSpeechRecognition={() => null}
+        description="Create a new entry"
+        heading="New journal entry"
+        submitLabel="Save entry"
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Voice dictation" }));
+    await user.click(screen.getByRole("button", { name: "Start dictation" }));
+
+    expect(getSourceInput()).toHaveValue("typed");
+    expect(
+      screen.getByText(
+        "This browser does not support live dictation yet. You can still type your entry.",
+      ),
+    ).toBeInTheDocument();
+  });
+
   it("stops active dictation when switching away from voice mode", async () => {
     const recognition = createRecognitionStub();
     const user = userEvent.setup();
@@ -120,5 +144,46 @@ describe("JournalCaptureForm", () => {
     expect(getSourceInput()).toHaveValue("ocr");
     expect(extractImageText).toHaveBeenCalledTimes(1);
     expect(screen.getByText(/Imported text from note\.png\./)).toBeInTheDocument();
+  });
+
+  it("keeps the editor read-only while OCR is in progress", async () => {
+    let releaseExtraction: (() => void) | null = null;
+    const extractImageText = vi
+      .fn<(file: File, onProgress: (progress: number) => void) => Promise<string>>()
+      .mockImplementation(
+        (_file, onProgress) =>
+          new Promise<string>((resolve) => {
+            onProgress(0.2);
+            releaseExtraction = () => resolve("OCR draft");
+          }),
+      );
+    const user = userEvent.setup();
+
+    render(
+      <JournalCaptureForm
+        action="/entries"
+        description="Create a new entry"
+        extractImageText={extractImageText}
+        heading="New journal entry"
+        submitLabel="Save entry"
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Handwriting OCR" }));
+    await user.upload(
+      screen.getByLabelText("Handwritten note image"),
+      new File(["note image"], "note.png", { type: "image/png" }),
+    );
+
+    expect(screen.getByLabelText("Entry")).toHaveAttribute("readonly");
+    expect(
+      screen.getByText("Wait for OCR to finish before editing the extracted text."),
+    ).toBeInTheDocument();
+
+    releaseExtraction?.();
+
+    await waitFor(() =>
+      expect(screen.getByLabelText("Entry")).not.toHaveAttribute("readonly"),
+    );
   });
 });

--- a/src/components/journal-capture-form.tsx
+++ b/src/components/journal-capture-form.tsx
@@ -174,11 +174,13 @@ export function JournalCaptureForm({
     setSource(nextSource);
   };
 
+  const isOcrProcessing = ocrProgress !== null && ocrProgress < 1;
+
   const startDictation = () => {
     const recognition = createSpeechRecognition();
 
     if (!recognition) {
-      setSource("voice");
+      setSource("typed");
       setVoiceError(
         "This browser does not support live dictation yet. You can still type your entry.",
       );
@@ -408,7 +410,7 @@ export function JournalCaptureForm({
             name="body"
             onChange={(event) => setEntryBody(event.target.value)}
             placeholder="Write or review the journal text you want to keep."
-            readOnly={isDictating}
+            readOnly={isDictating || isOcrProcessing}
             required
             value={entryBody}
           />
@@ -419,6 +421,14 @@ export function JournalCaptureForm({
             <p className="text-xs leading-5 text-muted">
               Stop dictation before editing the text manually.
             </p>
+          ) : null}
+          {isOcrProcessing ? (
+            <p className="text-xs leading-5 text-muted">
+              Wait for OCR to finish before editing the extracted text.
+            </p>
+          ) : null}
+          {voiceError && source !== "voice" ? (
+            <p className="text-xs leading-5 text-rose-700">{voiceError}</p>
           ) : null}
         </div>
 

--- a/src/components/journal-capture-form.tsx
+++ b/src/components/journal-capture-form.tsx
@@ -1,0 +1,387 @@
+"use client";
+
+import { useEffect, useRef, useState, type ChangeEvent, type ComponentProps } from "react";
+import { type CaptureSource, formatCaptureSource } from "@/lib/journal/capture-source";
+
+type BrowserSpeechRecognitionResult = {
+  0: {
+    transcript: string;
+  };
+  length: number;
+};
+
+type BrowserSpeechRecognitionEvent = {
+  results: ArrayLike<BrowserSpeechRecognitionResult>;
+};
+
+type BrowserSpeechRecognitionErrorEvent = {
+  error: string;
+};
+
+type BrowserSpeechRecognition = {
+  continuous: boolean;
+  interimResults: boolean;
+  lang: string;
+  onend: (() => void) | null;
+  onerror: ((event: BrowserSpeechRecognitionErrorEvent) => void) | null;
+  onresult: ((event: BrowserSpeechRecognitionEvent) => void) | null;
+  start: () => void;
+  stop: () => void;
+};
+
+type BrowserSpeechRecognitionConstructor = new () => BrowserSpeechRecognition;
+type FormAction = NonNullable<ComponentProps<"form">["action"]>;
+type WindowWithSpeechRecognition = Window & {
+  SpeechRecognition?: BrowserSpeechRecognitionConstructor;
+  webkitSpeechRecognition?: BrowserSpeechRecognitionConstructor;
+};
+
+type JournalCaptureFormProps = {
+  action: FormAction;
+  createSpeechRecognition?: () => BrowserSpeechRecognition | null;
+  description: string;
+  error?: string;
+  extractImageText?: (file: File, onProgress: (progress: number) => void) => Promise<string>;
+  heading: string;
+  submitLabel: string;
+};
+
+function appendCaptureText(baseText: string, addedText: string) {
+  const trimmedAddition = addedText.trim();
+
+  if (!trimmedAddition) {
+    return baseText;
+  }
+
+  const trimmedBase = baseText.trimEnd();
+  return trimmedBase ? `${trimmedBase} ${trimmedAddition}` : trimmedAddition;
+}
+
+function normalizeExtractedText(text: string) {
+  return text
+    .split("\n")
+    .map((line) => line.trimEnd())
+    .join("\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+function getVoiceErrorMessage(error: string) {
+  switch (error) {
+    case "audio-capture":
+      return "The microphone could not start. Check your browser permissions and try again.";
+    case "not-allowed":
+      return "Microphone access was blocked. Allow it in the browser to dictate.";
+    case "service-not-allowed":
+      return "This browser disabled speech recognition for the current page.";
+    default:
+      return "Dictation stopped before the transcript could finish. You can keep editing the text manually.";
+  }
+}
+
+export function createBrowserSpeechRecognition() {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  const SpeechRecognition =
+    (window as WindowWithSpeechRecognition).SpeechRecognition ??
+    (window as WindowWithSpeechRecognition).webkitSpeechRecognition;
+
+  return SpeechRecognition ? new SpeechRecognition() : null;
+}
+
+export async function extractImageTextWithTesseract(
+  file: File,
+  onProgress: (progress: number) => void,
+) {
+  const { recognize } = await import("tesseract.js");
+  const result = await recognize(file, "eng", {
+    logger(message) {
+      if (
+        message &&
+        typeof message === "object" &&
+        "status" in message &&
+        message.status === "recognizing text" &&
+        "progress" in message &&
+        typeof message.progress === "number"
+      ) {
+        onProgress(message.progress);
+      }
+    },
+  });
+
+  return result.data.text;
+}
+
+export function JournalCaptureForm({
+  action,
+  createSpeechRecognition = createBrowserSpeechRecognition,
+  description,
+  error,
+  extractImageText = extractImageTextWithTesseract,
+  heading,
+  submitLabel,
+}: JournalCaptureFormProps) {
+  const [entryBody, setEntryBody] = useState("");
+  const [source, setSource] = useState<CaptureSource>("typed");
+  const [isDictating, setIsDictating] = useState(false);
+  const [voiceMessage, setVoiceMessage] = useState<string | null>(null);
+  const [voiceError, setVoiceError] = useState<string | null>(null);
+  const [ocrMessage, setOcrMessage] = useState<string | null>(null);
+  const [ocrError, setOcrError] = useState<string | null>(null);
+  const [ocrProgress, setOcrProgress] = useState<number | null>(null);
+  const recognitionRef = useRef<BrowserSpeechRecognition | null>(null);
+  const dictationBaseTextRef = useRef("");
+  const voiceFailedRef = useRef(false);
+  const ocrRequestIdRef = useRef(0);
+
+  useEffect(() => {
+    return () => {
+      recognitionRef.current?.stop();
+    };
+  }, []);
+
+  const stopDictation = () => {
+    recognitionRef.current?.stop();
+  };
+
+  const startDictation = () => {
+    const recognition = createSpeechRecognition();
+
+    if (!recognition) {
+      setSource("voice");
+      setVoiceError(
+        "This browser does not support live dictation yet. You can still type your entry.",
+      );
+      setVoiceMessage(null);
+      return;
+    }
+
+    voiceFailedRef.current = false;
+    dictationBaseTextRef.current = entryBody;
+    recognition.continuous = true;
+    recognition.interimResults = true;
+    recognition.lang = "en-US";
+
+    recognition.onresult = (event) => {
+      const transcript = Array.from(
+        { length: event.results.length },
+        (_, index) => event.results[index]?.[0]?.transcript ?? "",
+      ).join(" ");
+
+      setEntryBody(appendCaptureText(dictationBaseTextRef.current, transcript));
+    };
+
+    recognition.onerror = (event) => {
+      voiceFailedRef.current = true;
+      setVoiceError(getVoiceErrorMessage(event.error));
+      setVoiceMessage(null);
+      setIsDictating(false);
+      recognitionRef.current = null;
+    };
+
+    recognition.onend = () => {
+      setIsDictating(false);
+      recognitionRef.current = null;
+
+      if (!voiceFailedRef.current) {
+        setVoiceMessage("Dictation stopped. Review and edit the transcript before saving.");
+      }
+    };
+
+    try {
+      recognition.start();
+      recognitionRef.current = recognition;
+      setSource("voice");
+      setVoiceError(null);
+      setVoiceMessage("Listening and adding transcript text into the editor...");
+      setIsDictating(true);
+    } catch {
+      setVoiceError("Dictation could not start. Try again or switch back to typing.");
+      setVoiceMessage(null);
+      setIsDictating(false);
+      recognitionRef.current = null;
+    }
+  };
+
+  const handleOcrUpload = async (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+
+    if (!file) {
+      return;
+    }
+
+    const requestId = ocrRequestIdRef.current + 1;
+    ocrRequestIdRef.current = requestId;
+    setSource("ocr");
+    setOcrError(null);
+    setOcrMessage(`Reading ${file.name}...`);
+    setOcrProgress(0);
+
+    try {
+      const extractedText = normalizeExtractedText(
+        await extractImageText(file, (progress) => {
+          if (ocrRequestIdRef.current === requestId) {
+            setOcrProgress(progress);
+          }
+        }),
+      );
+
+      if (ocrRequestIdRef.current !== requestId) {
+        return;
+      }
+
+      if (!extractedText) {
+        setOcrError(
+          "No readable text was found in that image. Try a sharper note photo or type the entry directly.",
+        );
+        setOcrMessage(null);
+        setOcrProgress(null);
+        return;
+      }
+
+      setEntryBody(extractedText);
+      setOcrError(null);
+      setOcrMessage(`Imported text from ${file.name}. Review and edit it before saving.`);
+      setOcrProgress(1);
+    } catch {
+      if (ocrRequestIdRef.current === requestId) {
+        setOcrError("That image could not be read. Try another file or switch to typing.");
+        setOcrMessage(null);
+        setOcrProgress(null);
+      }
+    } finally {
+      event.target.value = "";
+    }
+  };
+
+  return (
+    <section className="rounded-3xl border border-border/80 bg-card/95 p-6 shadow-sm sm:p-8">
+      <div className="space-y-2">
+        <h2 className="text-2xl font-semibold tracking-tight text-foreground">
+          {heading}
+        </h2>
+        <p className="text-sm leading-6 text-muted sm:text-base">{description}</p>
+      </div>
+
+      {error ? (
+        <div className="mt-4 rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700">
+          {error}
+        </div>
+      ) : null}
+
+      <form action={action} className="mt-6 space-y-4" method="post">
+        <div className="space-y-3">
+          <div className="flex flex-wrap gap-2" role="tablist" aria-label="Capture mode">
+            {(["typed", "voice", "ocr"] as const).map((mode) => {
+              const active = source === mode;
+
+              return (
+                <button
+                  aria-pressed={active}
+                  className={`inline-flex items-center justify-center rounded-full px-4 py-2 text-sm font-medium transition ${
+                    active
+                      ? "bg-slate-950 text-white"
+                      : "border border-border bg-white text-foreground hover:bg-slate-50"
+                  }`}
+                  key={mode}
+                  onClick={() => setSource(mode)}
+                  type="button"
+                >
+                  {formatCaptureSource(mode)}
+                </button>
+              );
+            })}
+          </div>
+
+          <div className="rounded-3xl border border-border bg-slate-50/70 p-4 text-sm text-muted">
+            {source === "typed" ? (
+              <p>Write directly in the editor and save it as a typed journal entry.</p>
+            ) : null}
+
+            {source === "voice" ? (
+              <div className="space-y-3">
+                <p>
+                  Use browser dictation to turn spoken notes into editable journal text.
+                </p>
+                <div className="flex flex-wrap items-center gap-3">
+                  <button
+                    className="inline-flex items-center justify-center rounded-full bg-slate-950 px-4 py-2 text-sm font-medium text-white transition hover:bg-slate-800"
+                    onClick={isDictating ? stopDictation : startDictation}
+                    type="button"
+                  >
+                    {isDictating ? "Stop dictation" : "Start dictation"}
+                  </button>
+                  <span className="text-xs leading-5 text-muted">
+                    Dictated text lands in the same editor below.
+                  </span>
+                </div>
+                {voiceMessage ? <p className="text-xs leading-5 text-sky-700">{voiceMessage}</p> : null}
+                {voiceError ? (
+                  <p className="text-xs leading-5 text-rose-700">{voiceError}</p>
+                ) : null}
+              </div>
+            ) : null}
+
+            {source === "ocr" ? (
+              <div className="space-y-3">
+                <label className="block space-y-2 text-sm font-medium text-foreground" htmlFor="ocr-file">
+                  <span>Handwritten note image</span>
+                  <input
+                    accept="image/*"
+                    className="block w-full rounded-2xl border border-border bg-white px-4 py-3 text-sm text-foreground file:mr-3 file:rounded-full file:border-0 file:bg-slate-950 file:px-4 file:py-2 file:text-sm file:font-medium file:text-white"
+                    id="ocr-file"
+                    onChange={handleOcrUpload}
+                    type="file"
+                  />
+                </label>
+                <p className="text-xs leading-5 text-muted">
+                  Upload a clear handwriting photo or scan. The extracted text replaces the editor draft so you can review it before saving.
+                </p>
+                {ocrMessage ? (
+                  <p className="text-xs leading-5 text-sky-700">
+                    {ocrMessage}
+                    {ocrProgress !== null && ocrProgress > 0 && ocrProgress < 1
+                      ? ` (${Math.round(ocrProgress * 100)}%)`
+                      : ""}
+                  </p>
+                ) : null}
+                {ocrError ? <p className="text-xs leading-5 text-rose-700">{ocrError}</p> : null}
+              </div>
+            ) : null}
+          </div>
+        </div>
+
+        <div className="space-y-2">
+          <label className="text-sm font-medium text-foreground" htmlFor="body">
+            Entry
+          </label>
+          <input name="source" type="hidden" value={source} />
+          <textarea
+            className="min-h-56 w-full rounded-3xl border border-border bg-white px-4 py-3 text-base text-foreground outline-none transition focus:border-sky-400 focus:ring-2 focus:ring-sky-200"
+            id="body"
+            maxLength={20_000}
+            name="body"
+            onChange={(event) => setEntryBody(event.target.value)}
+            placeholder="Write or review the journal text you want to keep."
+            required
+            value={entryBody}
+          />
+          <p className="text-xs leading-5 text-muted">
+            Saved entries keep the original capture source plus created and updated timestamps.
+          </p>
+        </div>
+
+        <div className="flex flex-wrap items-center gap-3">
+          <button
+            className="inline-flex items-center justify-center rounded-full bg-slate-950 px-5 py-3 text-sm font-medium text-white transition hover:bg-slate-800"
+            type="submit"
+          >
+            {submitLabel}
+          </button>
+        </div>
+      </form>
+    </section>
+  );
+}

--- a/src/components/journal-capture-form.tsx
+++ b/src/components/journal-capture-form.tsx
@@ -1,7 +1,11 @@
 "use client";
 
 import { useEffect, useRef, useState, type ChangeEvent, type ComponentProps } from "react";
-import { type CaptureSource, formatCaptureSource } from "@/lib/journal/capture-source";
+import {
+  captureSourceValues,
+  type CaptureSource,
+  formatCaptureSource,
+} from "@/lib/journal/capture-source";
 
 type BrowserSpeechRecognitionResult = {
   0: {
@@ -133,6 +137,7 @@ export function JournalCaptureForm({
   const [ocrProgress, setOcrProgress] = useState<number | null>(null);
   const recognitionRef = useRef<BrowserSpeechRecognition | null>(null);
   const dictationBaseTextRef = useRef("");
+  const dictationStopReasonRef = useRef<"manual" | "mode-switch" | null>(null);
   const voiceFailedRef = useRef(false);
   const ocrRequestIdRef = useRef(0);
 
@@ -142,8 +147,31 @@ export function JournalCaptureForm({
     };
   }, []);
 
-  const stopDictation = () => {
-    recognitionRef.current?.stop();
+  const stopDictation = (reason: "manual" | "mode-switch" = "manual") => {
+    if (!recognitionRef.current) {
+      return;
+    }
+
+    dictationStopReasonRef.current = reason;
+    setIsDictating(false);
+    recognitionRef.current.stop();
+  };
+
+  const selectSource = (nextSource: CaptureSource) => {
+    if (source === nextSource) {
+      return;
+    }
+
+    if (source === "voice" && nextSource !== "voice" && recognitionRef.current) {
+      stopDictation("mode-switch");
+    }
+
+    if (nextSource !== "voice") {
+      setVoiceError(null);
+      setVoiceMessage(null);
+    }
+
+    setSource(nextSource);
   };
 
   const startDictation = () => {
@@ -160,6 +188,7 @@ export function JournalCaptureForm({
 
     voiceFailedRef.current = false;
     dictationBaseTextRef.current = entryBody;
+    dictationStopReasonRef.current = null;
     recognition.continuous = true;
     recognition.interimResults = true;
     recognition.lang = "en-US";
@@ -182,10 +211,17 @@ export function JournalCaptureForm({
     };
 
     recognition.onend = () => {
+      const stopReason = dictationStopReasonRef.current;
+
+      dictationStopReasonRef.current = null;
       setIsDictating(false);
       recognitionRef.current = null;
 
       if (!voiceFailedRef.current) {
+        if (stopReason === "mode-switch") {
+          return;
+        }
+
         setVoiceMessage("Dictation stopped. Review and edit the transcript before saving.");
       }
     };
@@ -273,8 +309,8 @@ export function JournalCaptureForm({
 
       <form action={action} className="mt-6 space-y-4" method="post">
         <div className="space-y-3">
-          <div className="flex flex-wrap gap-2" role="tablist" aria-label="Capture mode">
-            {(["typed", "voice", "ocr"] as const).map((mode) => {
+          <div aria-label="Capture mode" className="flex flex-wrap gap-2" role="group">
+            {captureSourceValues.map((mode) => {
               const active = source === mode;
 
               return (
@@ -286,7 +322,7 @@ export function JournalCaptureForm({
                       : "border border-border bg-white text-foreground hover:bg-slate-50"
                   }`}
                   key={mode}
-                  onClick={() => setSource(mode)}
+                  onClick={() => selectSource(mode)}
                   type="button"
                 >
                   {formatCaptureSource(mode)}
@@ -308,7 +344,14 @@ export function JournalCaptureForm({
                 <div className="flex flex-wrap items-center gap-3">
                   <button
                     className="inline-flex items-center justify-center rounded-full bg-slate-950 px-4 py-2 text-sm font-medium text-white transition hover:bg-slate-800"
-                    onClick={isDictating ? stopDictation : startDictation}
+                    onClick={() => {
+                      if (isDictating) {
+                        stopDictation();
+                        return;
+                      }
+
+                      startDictation();
+                    }}
                     type="button"
                   >
                     {isDictating ? "Stop dictation" : "Start dictation"}
@@ -365,12 +408,18 @@ export function JournalCaptureForm({
             name="body"
             onChange={(event) => setEntryBody(event.target.value)}
             placeholder="Write or review the journal text you want to keep."
+            readOnly={isDictating}
             required
             value={entryBody}
           />
           <p className="text-xs leading-5 text-muted">
             Saved entries keep the original capture source plus created and updated timestamps.
           </p>
+          {isDictating ? (
+            <p className="text-xs leading-5 text-muted">
+              Stop dictation before editing the text manually.
+            </p>
+          ) : null}
         </div>
 
         <div className="flex flex-wrap items-center gap-3">

--- a/src/components/journal-entry-form.tsx
+++ b/src/components/journal-entry-form.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { useState } from "react";
+
 type JournalEntryFormProps = {
   action: string;
   body?: string;
@@ -19,6 +21,8 @@ export function JournalEntryForm({
   heading,
   submitLabel,
 }: JournalEntryFormProps) {
+  const [entryBody, setEntryBody] = useState(body ?? "");
+
   return (
     <section className="rounded-3xl border border-border/80 bg-card/95 p-6 shadow-sm sm:p-8">
       <div className="space-y-2">
@@ -41,13 +45,13 @@ export function JournalEntryForm({
           </label>
           <textarea
             className="min-h-56 w-full rounded-3xl border border-border bg-white px-4 py-3 text-base text-foreground outline-none transition focus:border-sky-400 focus:ring-2 focus:ring-sky-200"
-            defaultValue={body}
             id="body"
-            key={body ?? ""}
             maxLength={20_000}
             name="body"
+            onChange={(event) => setEntryBody(event.target.value)}
             placeholder="Write or review the journal text you want to keep."
             required
+            value={entryBody}
           />
           <p className="text-xs leading-5 text-muted">
             Saved entries keep the original capture source plus created and updated

--- a/src/components/journal-entry-form.tsx
+++ b/src/components/journal-entry-form.tsx
@@ -1,7 +1,3 @@
-"use client";
-
-import { useState } from "react";
-
 type JournalEntryFormProps = {
   action: string;
   body?: string;
@@ -21,8 +17,6 @@ export function JournalEntryForm({
   heading,
   submitLabel,
 }: JournalEntryFormProps) {
-  const [entryBody, setEntryBody] = useState(body ?? "");
-
   return (
     <section className="rounded-3xl border border-border/80 bg-card/95 p-6 shadow-sm sm:p-8">
       <div className="space-y-2">
@@ -45,16 +39,15 @@ export function JournalEntryForm({
           </label>
           <textarea
             className="min-h-56 w-full rounded-3xl border border-border bg-white px-4 py-3 text-base text-foreground outline-none transition focus:border-sky-400 focus:ring-2 focus:ring-sky-200"
+            defaultValue={body}
             id="body"
             maxLength={20_000}
             name="body"
-            onChange={(event) => setEntryBody(event.target.value)}
-            placeholder="Type the raw thought, feeling, or note you want to keep."
+            placeholder="Write or review the journal text you want to keep."
             required
-            value={entryBody}
           />
           <p className="text-xs leading-5 text-muted">
-            Saved entries keep the typed source label plus created and updated
+            Saved entries keep the original capture source plus created and updated
             timestamps.
           </p>
         </div>

--- a/src/components/journal-entry-form.tsx
+++ b/src/components/journal-entry-form.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 type JournalEntryFormProps = {
   action: string;
   body?: string;
@@ -41,6 +43,7 @@ export function JournalEntryForm({
             className="min-h-56 w-full rounded-3xl border border-border bg-white px-4 py-3 text-base text-foreground outline-none transition focus:border-sky-400 focus:ring-2 focus:ring-sky-200"
             defaultValue={body}
             id="body"
+            key={body ?? ""}
             maxLength={20_000}
             name="body"
             placeholder="Write or review the journal text you want to keep."

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,5 +1,6 @@
 import { sql } from "drizzle-orm";
 import { index, integer, pgEnum, pgTable, text, timestamp } from "drizzle-orm/pg-core";
+import { captureSourceValues } from "@/lib/journal/capture-source";
 
 const createdAt = timestamp("created_at", { withTimezone: true })
   .defaultNow()
@@ -10,7 +11,7 @@ const updatedAt = timestamp("updated_at", { withTimezone: true })
   .$onUpdate(() => new Date())
   .notNull();
 
-export const captureSource = pgEnum("capture_source", ["typed", "voice", "ocr"]);
+export const captureSource = pgEnum("capture_source", captureSourceValues);
 export const uploadKind = pgEnum("upload_kind", ["audio", "image"]);
 
 export const users = pgTable("users", {

--- a/src/lib/bootstrap.ts
+++ b/src/lib/bootstrap.ts
@@ -35,7 +35,7 @@ export function getBootstrapChecks(
     {
       configured: true,
       detail:
-        "The Next.js App Router shell is in place for auth, journaling, and reflection work.",
+        "The Next.js App Router shell is in place for auth, journaling, and multimodal capture work.",
       key: "shell",
       label: "Responsive shell",
     },
@@ -50,8 +50,8 @@ export function getBootstrapChecks(
     {
       configured: storageConfigured,
       detail: storageConfigured
-        ? "S3 connection values are present for the future uploads slice."
-        : "Set the S3_* values before wiring voice or handwriting uploads.",
+        ? "S3 connection values are present if you later want to retain original upload assets."
+        : "Set the S3_* values if you want to retain original uploaded media alongside extracted journal text.",
       key: "storage",
       label: "S3-compatible storage",
     },

--- a/src/lib/journal/capture-source.ts
+++ b/src/lib/journal/capture-source.ts
@@ -1,0 +1,18 @@
+export const captureSourceValues = ["typed", "voice", "ocr"] as const;
+
+export type CaptureSource = (typeof captureSourceValues)[number];
+const captureSourceSet = new Set<CaptureSource>(captureSourceValues);
+
+const captureSourceLabels: Record<CaptureSource, string> = {
+  ocr: "Handwriting OCR",
+  typed: "Typed",
+  voice: "Voice dictation",
+};
+
+export function formatCaptureSource(source: CaptureSource) {
+  return captureSourceLabels[source];
+}
+
+export function isCaptureSource(value: string): value is CaptureSource {
+  return captureSourceSet.has(value as CaptureSource);
+}

--- a/src/lib/journal/capture-source.ts
+++ b/src/lib/journal/capture-source.ts
@@ -1,6 +1,7 @@
 export const captureSourceValues = ["typed", "voice", "ocr"] as const;
 
 export type CaptureSource = (typeof captureSourceValues)[number];
+
 const captureSourceSet = new Set<CaptureSource>(captureSourceValues);
 
 const captureSourceLabels: Record<CaptureSource, string> = {

--- a/src/lib/journal/service.test.ts
+++ b/src/lib/journal/service.test.ts
@@ -18,6 +18,11 @@ const MOCK_ENTRY = {
   userId: "user-1",
 };
 
+const MOCK_VOICE_ENTRY = {
+  ...MOCK_ENTRY,
+  source: "voice" as const,
+};
+
 function mockInsertDb(returnRows: unknown[]) {
   return {
     insert: vi.fn().mockReturnValue({
@@ -71,7 +76,24 @@ describe("createJournalEntry", () => {
     await createJournalEntry({ body: "Test entry" }, "user-1", db);
     const valuesMock = (db.insert as ReturnType<typeof vi.fn>).mock.results[0]
       .value.values as ReturnType<typeof vi.fn>;
-    expect(valuesMock.mock.calls[0][0]).toMatchObject({ userId: "user-1" });
+    expect(valuesMock.mock.calls[0][0]).toMatchObject({
+      source: "typed",
+      userId: "user-1",
+    });
+  });
+
+  it("persists the selected non-typed source", async () => {
+    const db = mockInsertDb([MOCK_VOICE_ENTRY]);
+    const result = await createJournalEntry(
+      { body: "Test entry", source: "voice" },
+      "user-1",
+      db,
+    );
+    const valuesMock = (db.insert as ReturnType<typeof vi.fn>).mock.results[0]
+      .value.values as ReturnType<typeof vi.fn>;
+
+    expect(result).toEqual(MOCK_VOICE_ENTRY);
+    expect(valuesMock.mock.calls[0][0]).toMatchObject({ source: "voice" });
   });
 
   it("throws JournalError for empty body", async () => {

--- a/src/lib/journal/service.ts
+++ b/src/lib/journal/service.ts
@@ -3,11 +3,14 @@ import { and, desc, eq, sql } from "drizzle-orm";
 import { journalEntries } from "@/db/schema";
 import { getDatabase, type Database } from "@/lib/db/client";
 import {
-  journalEntryInputSchema,
+  journalEntryCreateInputSchema,
+  journalEntryUpdateInputSchema,
   journalSearchSchema,
-  type JournalEntryInput,
+  type JournalEntryCreateInput,
   type JournalSearchInput,
+  type JournalEntryUpdateInput,
 } from "@/lib/journal/validation";
+import { type CaptureSource } from "@/lib/journal/capture-source";
 
 export type JournalErrorCode = "invalid-input" | "not-found";
 
@@ -22,7 +25,7 @@ export type JournalEntryRecord = {
   body: string;
   createdAt: Date;
   id: string;
-  source: "typed" | "voice" | "ocr";
+  source: CaptureSource;
   updatedAt: Date;
   userId: string;
 };
@@ -38,8 +41,18 @@ const journalEntrySelect = {
   userId: journalEntries.userId,
 };
 
-function parseEntryInput(input: JournalEntryInput) {
-  const result = journalEntryInputSchema.safeParse(input);
+function parseCreateEntryInput(input: JournalEntryCreateInput) {
+  const result = journalEntryCreateInputSchema.safeParse(input);
+
+  if (!result.success) {
+    throw new JournalError("invalid-input");
+  }
+
+  return result.data;
+}
+
+function parseUpdateEntryInput(input: JournalEntryUpdateInput) {
+  const result = journalEntryUpdateInputSchema.safeParse(input);
 
   if (!result.success) {
     throw new JournalError("invalid-input");
@@ -49,17 +62,17 @@ function parseEntryInput(input: JournalEntryInput) {
 }
 
 export async function createJournalEntry(
-  input: JournalEntryInput,
+  input: JournalEntryCreateInput,
   userId: string,
   db: Database = getDatabase(),
 ) {
-  const entry = parseEntryInput(input);
+  const entry = parseCreateEntryInput(input);
   const [createdEntry] = await db
     .insert(journalEntries)
     .values({
       body: entry.body,
       id: randomUUID(),
-      source: "typed",
+      source: entry.source,
       userId,
     })
     .returning(journalEntrySelect);
@@ -69,11 +82,11 @@ export async function createJournalEntry(
 
 export async function updateJournalEntry(
   entryId: string,
-  input: JournalEntryInput,
+  input: JournalEntryUpdateInput,
   userId: string,
   db: Database = getDatabase(),
 ) {
-  const entry = parseEntryInput(input);
+  const entry = parseUpdateEntryInput(input);
   const [updatedEntry] = await db
     .update(journalEntries)
     .set({

--- a/src/lib/journal/validation.ts
+++ b/src/lib/journal/validation.ts
@@ -1,16 +1,25 @@
 import { z } from "zod";
+import { captureSourceValues } from "@/lib/journal/capture-source";
 
 const trimmedText = z.string().trim();
+const captureSourceSchema = z.enum(captureSourceValues);
+const journalEntryBodySchema = trimmedText
+  .min(1, "Write something before saving.")
+  .max(20_000, "Keep entries at 20,000 characters or fewer.");
 
-export const journalEntryInputSchema = z.object({
-  body: trimmedText
-    .min(1, "Write something before saving.")
-    .max(20_000, "Keep entries at 20,000 characters or fewer."),
+export const journalEntryCreateInputSchema = z.object({
+  body: journalEntryBodySchema,
+  source: captureSourceSchema.default("typed"),
+});
+
+export const journalEntryUpdateInputSchema = z.object({
+  body: journalEntryBodySchema,
 });
 
 export const journalSearchSchema = z.object({
   query: trimmedText.max(200).optional().transform((value) => value || undefined),
 });
 
-export type JournalEntryInput = z.infer<typeof journalEntryInputSchema>;
+export type JournalEntryCreateInput = z.input<typeof journalEntryCreateInputSchema>;
+export type JournalEntryUpdateInput = z.input<typeof journalEntryUpdateInputSchema>;
 export type JournalSearchInput = z.infer<typeof journalSearchSchema>;

--- a/tests/e2e/health.spec.ts
+++ b/tests/e2e/health.spec.ts
@@ -18,7 +18,7 @@ test("signed-out users are redirected to sign-in", async ({ page }) => {
   await expect(page).toHaveURL(/\/sign-in$/);
   await expect(
     page.getByRole("heading", {
-      name: "Private typed capture, ready when you are.",
+      name: "Private multimodal capture, ready when you are.",
     }),
   ).toBeVisible();
 });

--- a/tests/e2e/journal-mobile.spec.ts
+++ b/tests/e2e/journal-mobile.spec.ts
@@ -18,7 +18,7 @@ function createCredentials() {
   };
 }
 
-test("mobile layout keeps typed capture and history usable", async ({ page }) => {
+test("mobile layout keeps multimodal capture and history usable", async ({ page }) => {
   const credentials = createCredentials();
   const entryText = `Mobile journal entry ${credentials.uniqueId}`;
 
@@ -34,7 +34,9 @@ test("mobile layout keeps typed capture and history usable", async ({ page }) =>
     .click();
 
   await expect(page.getByRole("heading", { name: "Journal history" })).toBeVisible();
-  await expect(page.getByRole("heading", { name: "New typed entry" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "New journal entry" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Voice dictation" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Handwriting OCR" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Search" })).toBeVisible();
 
   await page.locator('form[action="/entries"] textarea[name="body"]').fill(entryText);

--- a/tests/e2e/journal.spec.ts
+++ b/tests/e2e/journal.spec.ts
@@ -31,13 +31,15 @@ test("desktop user can register, create, edit, search, sign out, and sign back i
     .click();
 
   await expect(page.getByRole("heading", { name: "Journal history" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Voice dictation" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Handwriting OCR" })).toBeVisible();
 
   await page.locator('form[action="/entries"] textarea[name="body"]').fill(initialEntry);
   await page.getByRole("button", { name: "Save entry" }).click();
 
   await expect(page).toHaveURL(/\/entries\/.+\?message=created$/);
   await expect(page.getByText(initialEntry)).toBeVisible();
-  await expect(page.getByText("typed", { exact: true })).toBeVisible();
+  await expect(page.getByText("Typed", { exact: true })).toBeVisible();
 
   await page.getByRole("link", { name: "Edit entry" }).click();
   await expect(page).toHaveURL(/\/entries\/.+\/edit$/);


### PR DESCRIPTION
## Summary
- add a multimodal create flow for typed input, browser voice dictation, and handwriting OCR
- persist capture source on creation and surface friendly source labels across the archive and entry detail views
- expand unit and Playwright coverage for the new capture modes and copy updates

Closes #19